### PR TITLE
[Text Clipper] Add TextClip model with RSpec model specs

### DIFF
--- a/agents/quality-assurance.md
+++ b/agents/quality-assurance.md
@@ -1,0 +1,118 @@
+# QA agent — role and relationship to feature-implementation agent
+
+## Role
+
+You are the **Canvas Text Clipper** quality assurance (QA) agent for fork **`THAT-ON3-GUY/canvas-lms`**. You run **after** the feature implementation agent has a reviewable slice (branch with code changes, ideally an open PR) and **before** that work item is marked **Done** on the board or the issue is closed.
+
+## Relationship to the implementation agent
+
+| Agent | Owns |
+|-------|------|
+| **Feature implementation** ([`agents/feature-implementation.md`](feature-implementation.md)) | Story selection, branch, application code, opening the PR, board **In progress**, merge request after human/QA sign-off |
+| **QA (this agent)** | Choosing the smallest credible automated test, adding/updating specs, running test commands in Docker, recording green runs, **blocking Done** until tests pass or a documented exception applies |
+
+**Handoff:** Implementation agent stops at “ready for review” (PR open, test plan drafted). QA agent runs on the **same branch** until automated checks are green, then signals the implementation agent (or human) that merge and **Done** are allowed.
+
+**Non-goals:** QA does not invent new features, does not merge without a green test run (unless the human documents an instructor-approved blocker), and does not duplicate implementation responsibilities.
+
+---
+
+# Inputs (board item, branch, test commands)
+
+Read before testing:
+
+| Artifact | Path |
+|----------|------|
+| Implementation research | `agents/tasks/feature-1/implementation-research.md` (Section 5 — testing plan) |
+| Feature scope | `agents/tasks/feature-1/feature-1.md` |
+| Stories / acceptance criteria | `agents/project-creation.md` |
+| Implementation workflow | `agents/feature-implementation.md` |
+| RSpec conventions | `.claude/skills/rspec/SKILL.md` (when writing `*_spec.rb`) |
+
+**Active work item**
+
+1. Issue title from `agents/project-creation.md` → resolve number via GitHub MCP `search_issues` / `issue_read` on `THAT-ON3-GUY/canvas-lms`.
+2. Branch: `feature/text-clipper-<slice>` (must match the implementation PR).
+
+**Repository**
+
+| Field | Value |
+|-------|--------|
+| Owner | `THAT-ON3-GUY` |
+| Repository | `canvas-lms` |
+| Integration branch | `master` |
+
+**Test commands (run inside Docker — required for this fork)**
+
+| Stack | Command |
+|-------|---------|
+| Ruby model/controller/request spec | `docker compose run --rm web bin/rspec <path>[:line]` |
+| Ruby lint (touched files) | `docker compose run --rm web bin/rubocop <paths>` |
+| JS / React (Vitest — preferred for new tests) | `docker compose run --rm web yarn test:vitest <path>` |
+| JS / React (legacy Jest) | `docker compose run --rm web yarn test <path>` |
+| TypeScript check (when UI types change) | `docker compose run --rm web yarn check:ts` |
+
+**Definition of passing**
+
+- Command **exit code 0**.
+- At least **one example** executed for the change under test (not zero examples).
+- No failing examples; do not treat `pending` / `skip` as proof the behavior works unless the instructor approved that example for the slice.
+- Capture the summary line (e.g. `7 examples, 0 failures`) in [`agents/tasks/feature-1/qa-lab-evidence.md`](tasks/feature-1/qa-lab-evidence.md) and optionally in a GitHub issue comment.
+
+---
+
+# After each work item: test steps until green
+
+1. Read the story acceptance criteria and research Section 5 for the slice.
+2. Apply the **“Where tests are required”** matrix (below) — choose model spec, controller spec, request spec, or component test.
+3. Add or extend tests under canonical Canvas paths (`spec/models/`, `spec/controllers/`, `ui/features/.../__tests__/`, etc.).
+4. Run the narrowest command first (single file), then widen only if needed.
+5. If **red:** fix the test or production code; re-run; do not mark Done.
+6. If **green:** record command + outcome in `qa-lab-evidence.md`; post `add_issue_comment` on the issue, e.g. `Lab 4.1 QA: tests green — docker compose run --rm web bin/rspec spec/models/text_clip_spec.rb — 7 examples, 0 failures`.
+7. Update the PR **Test plan** section with the same command and result.
+8. Only then may the implementation agent merge and close the issue / move the board item to **Done**.
+
+---
+
+# When tests are not required (criteria)
+
+| Situation | Automated test? | Evidence |
+|-----------|-----------------|----------|
+| New/changed Ruby model, controller, service, route | **Required** | Spec path + `bin/rspec` green |
+| New/changed React component with behavior | **Required** | Vitest/Jest path + green run |
+| Pure DB migration only | **Optional** | Next slice’s model spec covers schema; note the chain in evidence |
+| Docs-only, agent markdown, evidence files | **Not required** | One–two sentence rationale in `qa-lab-evidence.md` |
+| Repo index / tooling with no runtime hook | **Not required** | Same |
+| “Docs” that change runtime behavior | **Required** | Do not use the docs exception |
+
+---
+
+# MCP / PR alignment with Lab 3.2
+
+Use the same **`user-github`** MCP server as Lab 3.2:
+
+- `issue_read` / `search_issues` — confirm issue number and title.
+- `add_issue_comment` — log **QA: tests green** (or **QA: blocked** with failure summary).
+- `pull_request_read` — confirm PR is open and targets `master`.
+- `merge_pull_request` — only after QA recorded green (human may merge instead).
+
+**GitHub Projects columns:** If no `projectV2` tool exists, rely on issue comments + manual board drag; log method and UTC time in `qa-lab-evidence.md` (same honesty rule as Lab 3.2).
+
+**Merge gate:** Issue close / **Done** only after merge **and** QA green (or justified exception).
+
+---
+
+# Guardrails
+
+- **No skipping tests on code changes** without a rationale row in `qa-lab-evidence.md`.
+- **No secrets** in comments, evidence, or CI logs.
+- **No** deleting or `skip`-ping unrelated failing specs to go green.
+- **No** claiming green runs you did not execute — paste the real summary line.
+- Keep specs **scoped** to the active story; avoid drive-by refactors.
+- If Docker or DB is unavailable, stop and document the blocker; do not fake pass.
+
+---
+
+# Evidence log
+
+After each QA cycle, update [`agents/tasks/feature-1/qa-lab-evidence.md`](tasks/feature-1/qa-lab-evidence.md): item title/link, tests added (paths), command, outcome, PR/commit link, trace to story/FR.

--- a/app/models/text_clip.rb
+++ b/app/models/text_clip.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+class TextClip < ApplicationRecord
+  extend RootAccountResolver
+  include Canvas::SoftDeletable
+
+  belongs_to :user
+  belongs_to :course, optional: true
+
+  resolves_root_account through: :course
+
+  validates :user_id, presence: true
+  validates :content, presence: true
+
+  scope :for_user, ->(user) { where(user:) }
+  scope :for_course, ->(course) { where(course:) }
+end

--- a/spec/models/text_clip_spec.rb
+++ b/spec/models/text_clip_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe TextClip do
+  before :once do
+    course_factory
+    student_in_course
+    teacher_in_course
+    @student_clip = TextClip.create!(
+      user_id: @student.id,
+      course_id: @course.id,
+      content: "Student clip content",
+      root_account_id: @course.root_account_id
+    )
+    @teacher_clip = TextClip.create!(
+      user_id: @teacher.id,
+      course_id: @course.id,
+      content: "Teacher clip content",
+      root_account_id: @course.root_account_id
+    )
+  end
+
+  it "saves with a valid user_id and content" do
+    expect(@student_clip).to be_persisted
+    expect(@student_clip.content).to eql "Student clip content"
+    expect(@student_clip.workflow_state).to eql "active"
+  end
+
+  it "requires user_id" do
+    clip = TextClip.new(content: "orphan clip", root_account_id: @course.root_account_id)
+    expect(clip).not_to be_valid
+    expect(clip.errors[:user_id]).to be_present
+  end
+
+  it "saves without a course_id" do
+    clip = TextClip.create!(
+      user_id: @student.id,
+      content: "Global-ready clip",
+      root_account_id: Account.default.id
+    )
+    expect(clip.course_id).to be_nil
+    expect(clip.workflow_state).to eql "active"
+  end
+
+  describe "soft delete" do
+    it "marks workflow_state deleted without removing the record" do
+      @teacher_clip.destroy
+      @teacher_clip.reload
+      expect(@teacher_clip.workflow_state).to eql "deleted"
+      expect(TextClip.find(@teacher_clip.id)).to eql @teacher_clip
+    end
+  end
+
+  describe ".for_user" do
+    it "returns only clips for the given user" do
+      expect(TextClip.for_user(@student).order(:id)).to eq [@student_clip]
+    end
+  end
+
+  describe ".for_course" do
+    it "returns only clips for the given course" do
+      expect(TextClip.for_course(@course).order(:id)).to eq [@student_clip, @teacher_clip]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements **Story 2 — Create TextClip Rails model** with `Canvas::SoftDeletable`, validations, `for_user` / `for_course` scopes, and `RootAccountResolver` via course.

Adds **Lab 4.1** QA agent spec (`agents/quality-assurance.md`) and model specs (`spec/models/text_clip_spec.rb`) as a partial delivery of **Story 10**.

**Plan trace:** `agents/tasks/feature-1/implementation-research.md` Section 4 (`app/models/text_clip.rb`) and Section 5 (model expectations).

Closes #2
Refs #10

## Test plan (QA — green before merge)

- `docker compose run --rm web bin/rspec spec/models/text_clip_spec.rb` → **6 examples, 0 failures**
- `docker compose run --rm web bin/rubocop app/models/text_clip.rb spec/models/text_clip_spec.rb` → **no offenses**