### PR TITLE
[Text Clipper] Add TextClipsController and API routes

### DIFF
--- a/app/controllers/text_clips_controller.rb
+++ b/app/controllers/text_clips_controller.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+class TextClipsController < ApplicationController
+  before_action :require_user
+  before_action :require_context_and_read_access
+
+  def index
+    clips = @context.shard.activate do
+      TextClip.active.where(user_id: @current_user.id, course_id: @context.id).order(created_at: :desc)
+    end
+    render json: clips.map { |clip| text_clip_json(clip) }
+  end
+
+  def create
+    clip = nil
+    @context.shard.activate do
+      clip = TextClip.new(
+        user_id: @current_user.id,
+        course_id: @context.id,
+        content: params[:content],
+        source_url: params[:source_url],
+        root_account_id: @context.root_account_id
+      )
+      clip.save
+    end
+    if clip&.persisted?
+      render json: text_clip_json(clip), status: :created
+    else
+      render json: clip&.errors || {}, status: :bad_request
+    end
+  end
+
+  def destroy
+    clip = @context.shard.activate do
+      TextClip.active.where(user_id: @current_user.id).find(params[:id])
+    end
+    clip.destroy
+    render json: text_clip_json(clip), status: :ok
+  end
+
+  private
+
+  def text_clip_json(clip)
+    {
+      id: clip.id,
+      user_id: clip.user_id,
+      course_id: clip.course_id,
+      content: clip.content,
+      source_url: clip.source_url,
+      workflow_state: clip.workflow_state,
+      created_at: clip.created_at,
+      updated_at: clip.updated_at
+    }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,7 @@ class User < ApplicationRecord
   has_one :communication_channel, -> { unretired.ordered }
   has_many :ignores
   has_many :planner_notes, dependent: :destroy
+  has_many :text_clips, dependent: :destroy, multishard: true
   has_many :viewed_submission_comments, dependent: :destroy
 
   has_many :enrollments, dependent: :destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2885,6 +2885,12 @@ CanvasRails::Application.routes.draw do
       delete "planner_notes/:id", action: :destroy
     end
 
+    scope(controller: :text_clips) do
+      get "courses/:course_id/text_clips", action: :index, as: :course_text_clips
+      post "courses/:course_id/text_clips", action: :create
+      delete "courses/:course_id/text_clips/:id", action: :destroy
+    end
+
     scope(controller: :content_shares) do
       post "users/:user_id/content_shares", action: :create
       get "users/:user_id/content_shares/sent", action: :index, defaults: { list: "sent" }, as: :user_sent_content_shares

--- a/spec/controllers/text_clips_controller_spec.rb
+++ b/spec/controllers/text_clips_controller_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe TextClipsController do
+  before :once do
+    course_with_teacher_and_student_enrolled(active_all: true)
+    @other_course = course_factory(active_all: true)
+  end
+
+  def create_clip_for(user, course, content)
+    course.shard.activate do
+      TextClip.create!(
+        user_id: user.id,
+        course_id: course.id,
+        content:,
+        root_account_id: course.root_account_id
+      )
+    end
+  end
+
+  context "unauthenticated" do
+    it "returns unauthorized for index" do
+      get :index, format: :json, params: { course_id: @course.id }
+      assert_unauthorized
+    end
+
+    it "returns unauthorized for create" do
+      post :create, format: :json, params: { course_id: @course.id, content: "new clip" }
+      assert_unauthorized
+    end
+  end
+
+  context "authenticated as teacher" do
+    before do
+      user_session(@teacher)
+      @teacher_clip = create_clip_for(@teacher, @course, "Teacher clip")
+      @student_clip = create_clip_for(@student, @course, "Student clip")
+    end
+
+    describe "GET #index" do
+      it "returns only the current user's clips for the course" do
+        get :index, format: :json, params: { course_id: @course.id }
+        expect(response).to be_successful
+        clip_ids = json_parse(response.body).pluck("id")
+        expect(clip_ids).to eq [@teacher_clip.id]
+        expect(clip_ids).not_to include(@student_clip.id)
+      end
+    end
+
+    describe "POST #create" do
+      it "creates a clip for the current user and course" do
+        post :create, format: :json, params: {
+          course_id: @course.id,
+          content: "New clip content",
+          source_url: "https://example.com/page"
+        }
+        expect(response).to have_http_status(:created)
+        body = json_parse(response.body)
+        clip = @course.shard.activate { TextClip.find(body["id"]) }
+        expect(clip.user_id).to eq @teacher.id
+        expect(clip.course_id).to eq @course.id
+        expect(clip.content).to eql "New clip content"
+      end
+
+      it "returns forbidden when the user cannot read the course" do
+        user_session(@student)
+        post :create, format: :json, params: { course_id: @other_course.id, content: "blocked clip" }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "DELETE #destroy" do
+      it "soft-deletes the current user's clip" do
+        delete :destroy, format: :json, params: { course_id: @course.id, id: @teacher_clip.id }
+        expect(response).to be_successful
+        expect(@course.shard.activate { @teacher_clip.reload.workflow_state }).to eql "deleted"
+      end
+
+      it "returns not found for another user's clip" do
+        delete :destroy, format: :json, params: { course_id: @course.id, id: @student_clip.id }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements **Story 3** (`TextClipsController` with `index`, `create`, `destroy`) and **Story 4** (course-nested routes under `/api/v1/courses/:course_id/text_clips`). Partial **Story 10** controller specs.

- Shard-aware queries via `@context.shard.activate`
- User-scoped clips; 404 for other users' clips; 403 when course is not readable
- `has_many :text_clips, multishard: true` on `User`

Closes #3
Closes #4
Refs #10

## Test plan (QA — green before merge)

- `docker compose run --rm web bin/rspec spec/controllers/text_clips_controller_spec.rb` → **7 examples, 0 failures**
- `docker compose run --rm web bin/rubocop app/controllers/text_clips_controller.rb spec/controllers/text_clips_controller_spec.rb config/routes.rb` → **no offenses**