### PR TITLE
Add Text Clipper slice 4 tags and filtering

### DIFF
--- a/.cursor/plans/text_clipper_slice_4.plan.md
+++ b/.cursor/plans/text_clipper_slice_4.plan.md
@@ -1,0 +1,535 @@
+---
+name: Text Clipper — Slice 4 (tags, colors, and filtering)
+overview: "Let users organize the tray with their own tags. Tags are per-user (cross-course), color-coded from a fixed palette, and applied to clips via the existing inline editor. The tray gains a filter row above the search input so users can narrow by tag. Backend adds `clip_tags` and `text_clip_taggings` tables (sharded, soft-deletable), a `ClipTagsController` CRUD under `/api/v1/users/self/clip_tags`, and an idempotent `tag_ids: []` argument on `TextClipsController#update` plus a `tag_ids[]` filter on `#index`. Out of scope: tag-only nav menu, drag-to-tag, bulk operations, tag analytics, global (course-less) clips UI."
+todos:
+  - id: migration_clip_tags
+    content: db/migrate/<TS>_create_clip_tags.rb — predeploy create_table with user_id, name, color, workflow_state, root_account_id, replica_identity_index, unique(user_id, lower(name)) where active
+    status: completed
+  - id: migration_text_clip_taggings
+    content: db/migrate/<TS+1>_create_text_clip_taggings.rb — predeploy join table (text_clip_id, clip_tag_id, root_account_id, timestamps), unique(text_clip_id, clip_tag_id) where active, replica_identity_index
+    status: pending
+  - id: model_clip_tag
+    content: app/models/clip_tag.rb — SoftDeletable, RootAccountResolver through :user, belongs_to :user; validates name presence/length (1..64) and color inclusion in palette; scope :for_user; scope :active
+    status: pending
+  - id: model_text_clip_tagging
+    content: app/models/text_clip_tagging.rb — SoftDeletable, RootAccountResolver through :text_clip, belongs_to :text_clip and :clip_tag; uniqueness validation scoped to text_clip (active)
+    status: pending
+  - id: model_text_clip_assoc
+    content: app/models/text_clip.rb — has_many :text_clip_taggings, has_many :clip_tags through it (active); add scope :with_any_tag(tag_ids) using joins; extend `searchable` to leave tags alone (filter handled at controller)
+    status: pending
+  - id: user_assoc_tags
+    content: "app/models/user.rb — has_many :clip_tags, dependent: :destroy, multishard: true"
+    status: pending
+  - id: serializer_clip_tag
+    content: lib/api/v1/clip_tag.rb — clip_tag_json / clip_tags_json including id, name, color, workflow_state, created_at, updated_at
+    status: pending
+  - id: serializer_text_clip_with_tags
+    content: lib/api/v1/text_clip.rb — include `tags` array (id, name, color) when serializing text clips via preloaded :clip_tags
+    status: pending
+  - id: controller_clip_tags
+    content: app/controllers/clip_tags_controller.rb — index/create/update/destroy under @current_user, paginated index, name uniqueness via 422, soft-delete on destroy; reuse find_for_current_user pattern
+    status: pending
+  - id: controller_text_clips_filter_and_tags
+    content: "app/controllers/text_clips_controller.rb — #index accepts tag_ids[] (OR filter), preloads :clip_tags; #update accepts tag_ids[] and idempotently replaces taggings; #create still ignores tags (tag later)"
+    status: pending
+  - id: routes_clip_tags
+    content: "config/routes.rb — add scope(controller: :clip_tags) for users/self/clip_tags GET/POST + clip_tags/:id PUT/DELETE inside ApiRouteSet::V1.draw"
+    status: pending
+  - id: frontend_api_tags
+    content: ui/features/text_clips/api.ts + types.ts — ClipTagRecord, fetchClipTags/createClipTag/updateClipTag/deleteClipTag; updateTextClip body gains tag_ids?; textClipsIndexPath accepts tagIds?
+    status: pending
+  - id: frontend_tray_tag_chips
+    content: TextClipsTray.tsx — render `Tag` chips below each clip's content (color matched to palette) and inside the inline editor a multi-select tag picker with a 'New tag' inline create; saves via existing PUT
+    status: pending
+  - id: frontend_tray_filter_row
+    content: "TextClipsTray.tsx — above the search input add a horizontally-scrollable strip of clickable tag chips for the current user; clicking toggles into a `selectedTagIds: Set` that drives the query (tag_ids[]); 'Clear' button when any selected"
+    status: pending
+  - id: frontend_manage_tags_panel
+    content: TextClipsTray.tsx — small `Manage tags` button opens a collapsible panel inside the tray listing all of the user's tags with inline rename + delete; uses existing useMutation pattern; invalidates ['clip_tags']
+    status: pending
+  - id: backend_specs_slice4
+    content: "spec/models/clip_tag_spec.rb, spec/models/text_clip_tagging_spec.rb, spec/controllers/clip_tags_controller_spec.rb, extend spec/controllers/text_clips_controller_spec.rb (#index tag_ids filter, #update tag_ids replace, cross-user 404, serialized tags array)"
+    status: pending
+  - id: frontend_tests_slice4
+    content: Update api.test.ts (new tag wrappers + updateTextClip tag_ids) and TextClipsTray.test.tsx (tag chip render, tag filter narrows query, tag picker in editor PUTs tag_ids, manage panel creates/renames/deletes)
+    status: pending
+  - id: verify_slice4
+    content: Run db:migrate (test + dev), bin/rspec, yarn test, yarn check:ts, bin/rubocop on touched Ruby; walk through Slice-4 manual checklist
+    status: pending
+isProject: false
+---
+
+# Text Clipper — Slice 4 plan
+
+Slices 1–3 give us: clip CRUD, soft-delete, source link, search, pagination, edit, notes, undo. Once a user accumulates 30+ clips, search alone isn't enough — they want **lateral structure**. Slice 4 adds **personal tags** (per-user, color-coded, cross-course) and the ability to **filter the tray by tag**.
+
+Tags are deliberately **user-scoped**, not course-scoped, so the same "Important" or "Exam prep" tag works across every course the user takes. The tray remains course-scoped: it only ever shows clips for the current course, but the available tag set is global to the user.
+
+## Architecture delta
+
+```mermaid
+flowchart LR
+  subgraph User
+    Tags["clip_tags<br/>(per-user)"]
+  end
+  subgraph Course
+    Clips["text_clips<br/>(per user × course)"]
+    Tagging["text_clip_taggings<br/>(join)"]
+  end
+  Tags --- Tagging
+  Clips --- Tagging
+
+  Tray["TextClipsTray<br/>filter chips + tag picker"]
+  TagAPI["ClipTagsController<br/>(users/self/clip_tags)"]
+  ClipAPI["TextClipsController<br/>#index tag_ids[], #update tag_ids[]"]
+
+  Tray -- "GET /users/self/clip_tags" --> TagAPI
+  Tray -- "GET /text_clips?tag_ids[]=" --> ClipAPI
+  Tray -- "PUT /text_clips/:id { tag_ids: [...] }" --> ClipAPI
+```
+
+Two new tables, both sharded, both soft-deletable. No changes to `text_clips` columns.
+
+## Backend (Rails)
+
+### 1. Migrations
+
+`db/migrate/<TS>_create_clip_tags.rb` — modeled after `CreateInstitutionalTags`:
+
+```ruby
+create_table :clip_tags do |t|
+  t.references :user, null: false, foreign_key: true
+  t.string :name, null: false, limit: 64
+  t.string :color, null: false, default: "blue", limit: 32
+  t.string :workflow_state, null: false, default: "active", limit: 255
+  t.references :root_account, null: false, foreign_key: { to_table: :accounts }, index: false
+  t.timestamps
+
+  t.check_constraint "workflow_state IN ('active', 'deleted')", name: "chk_clip_tags_workflow_state_enum"
+  t.replica_identity_index
+  t.index "user_id, LOWER(name)",
+          unique: true,
+          where: "workflow_state = 'active'",
+          name: "index_clip_tags_on_user_id_lower_name_active"
+end
+```
+
+`db/migrate/<TS+1>_create_text_clip_taggings.rb`:
+
+```ruby
+create_table :text_clip_taggings do |t|
+  t.references :text_clip, null: false, foreign_key: true
+  t.references :clip_tag,  null: false, foreign_key: true
+  t.references :root_account, null: false, foreign_key: { to_table: :accounts }, index: false
+  t.string :workflow_state, null: false, default: "active", limit: 255
+  t.timestamps
+
+  t.check_constraint "workflow_state IN ('active', 'deleted')", name: "chk_text_clip_taggings_workflow_state_enum"
+  t.replica_identity_index
+  t.index %i[text_clip_id clip_tag_id],
+          unique: true,
+          where: "workflow_state = 'active'",
+          name: "index_text_clip_taggings_unique_active"
+end
+```
+
+### 2. Models
+
+`app/models/clip_tag.rb`:
+
+```ruby
+class ClipTag < ApplicationRecord
+  extend RootAccountResolver
+  include Canvas::SoftDeletable
+
+  PALETTE = %w[blue green orange purple red gray yellow pink].freeze
+
+  belongs_to :user
+  has_many :text_clip_taggings, dependent: :destroy
+  has_many :text_clips, through: :text_clip_taggings
+
+  resolves_root_account through: :user
+
+  validates :name, presence: true, length: { maximum: 64 }
+  validates :color, inclusion: { in: PALETTE }
+  validates :workflow_state, presence: true
+  validates :name, uniqueness: { scope: :user_id, conditions: -> { active }, case_sensitive: false }
+
+  scope :for_user, ->(user) { where(user:) }
+end
+```
+
+`app/models/text_clip_tagging.rb`:
+
+```ruby
+class TextClipTagging < ApplicationRecord
+  extend RootAccountResolver
+  include Canvas::SoftDeletable
+
+  belongs_to :text_clip
+  belongs_to :clip_tag
+
+  resolves_root_account through: :text_clip
+
+  validates :workflow_state, presence: true
+  validates :clip_tag_id, uniqueness: {
+    scope: :text_clip_id,
+    conditions: -> { active },
+    case_sensitive: false,
+    message: "tag already applied to this clip"
+  }
+end
+```
+
+`app/models/text_clip.rb` additions:
+
+```ruby
+has_many :text_clip_taggings, dependent: :destroy
+has_many :clip_tags, -> { active }, through: :text_clip_taggings
+
+scope :with_any_tag, ->(tag_ids) {
+  next all if Array(tag_ids).compact.blank?
+
+  joins(:text_clip_taggings)
+    .where(text_clip_taggings: { clip_tag_id: tag_ids, workflow_state: "active" })
+    .distinct
+}
+```
+
+`app/models/user.rb` additions:
+
+```ruby
+has_many :clip_tags, dependent: :destroy, multishard: true
+```
+
+### 3. Serializers
+
+`lib/api/v1/clip_tag.rb`:
+
+```ruby
+module Api::V1::ClipTag
+  include Api::V1::Json
+
+  API_JSON_OPTS = {
+    only: %w[id name color workflow_state created_at updated_at]
+  }.freeze
+
+  def clip_tag_json(tag, user, session, opts = {})
+    api_json(tag, user, session, opts.merge(API_JSON_OPTS))
+  end
+
+  def clip_tags_json(tags, user, session, opts = {})
+    tags.map { |t| clip_tag_json(t, user, session, opts) }
+  end
+end
+```
+
+`lib/api/v1/text_clip.rb` — change `text_clip_json` to also embed an array of tag stubs:
+
+```ruby
+def text_clip_json(clip, user, session, opts = {})
+  json = api_json(clip, user, session, opts.merge(API_JSON_OPTS))
+  json["tags"] = clip.clip_tags.map { |t| { "id" => t.id, "name" => t.name, "color" => t.color } }
+  json
+end
+```
+
+(The N+1 cost is handled by the controller preloading `:clip_tags`.)
+
+### 4. Controllers
+
+`app/controllers/clip_tags_controller.rb` — small CRUD scoped to `@current_user`:
+
+```ruby
+class ClipTagsController < ApplicationController
+  include Api::V1::ClipTag
+
+  before_action :require_user
+
+  def index
+    tags = @current_user.clip_tags.active.order(:name)
+    paginated = Api.paginate(tags, self, api_v1_user_clip_tags_url("self"))
+    render json: clip_tags_json(paginated, @current_user, session)
+  end
+
+  def create
+    tag = @current_user.clip_tags.build(create_params.merge(root_account_id: @domain_root_account.id))
+    if tag.save
+      render json: clip_tag_json(tag, @current_user, session), status: :created
+    else
+      render json: tag.errors, status: :unprocessable_content
+    end
+  end
+
+  def update
+    tag = find_for_current_user(active: true)
+    return unless tag.is_a?(ClipTag)
+
+    if tag.update(update_params)
+      render json: clip_tag_json(tag, @current_user, session)
+    else
+      render json: tag.errors, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    tag = find_for_current_user(active: true)
+    return unless tag.is_a?(ClipTag)
+
+    tag.destroy
+    render json: clip_tag_json(tag, @current_user, session)
+  end
+
+  private
+
+  def find_for_current_user(active:)
+    scope = @current_user.clip_tags
+    scope = scope.active if active
+    scope.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { errors: [{ message: "not found" }] }, status: :not_found
+    nil
+  end
+
+  def create_params
+    params.permit(:name, :color)
+  end
+
+  def update_params
+    params.permit(:name, :color)
+  end
+end
+```
+
+`app/controllers/text_clips_controller.rb` changes:
+
+- `#index` — preload `:clip_tags`; accept `tag_ids[]` (Array of integers) and chain `with_any_tag(tag_ids)`. Validate ids are integers; ignore unknown ids silently rather than 404.
+- `#update` — if `tag_ids` is present in params, treat it as an **idempotent replacement** of the clip's taggings. Implementation: in the same transaction, soft-delete taggings for tags not in the new set, and `find_or_create_by` taggings for tags in the new set. Cross-user safety: only consider tag ids that belong to `@current_user.clip_tags`.
+- `#create` — no change (tags are applied via `#update` after creation; selection clip stays minimal).
+
+```ruby
+def index
+  q = params[:q].to_s
+  return unprocessable_search_term if q.present? && !SearchTermHelper.valid_search_term?(q)
+
+  tag_ids = Array(params[:tag_ids]).map(&:to_i).reject(&:zero?)
+
+  clips = @context.shard.activate do
+    @current_user.text_clips
+                 .active
+                 .for_course(@context)
+                 .searchable(q)
+                 .with_any_tag(tag_ids)
+                 .preload(:clip_tags)
+                 .order(created_at: :desc)
+  end
+  paginated = Api.paginate(clips, self, api_v1_course_text_clips_url(@context))
+  render json: text_clips_json(paginated, @current_user, session)
+end
+
+def update
+  clip = find_clip_for_current_user(active: true)
+  return unless clip.is_a?(TextClip)
+
+  attrs = normalized_update_params
+  tag_ids = params.key?(:tag_ids) ? Array(params[:tag_ids]).map(&:to_i).reject(&:zero?) : nil
+
+  ok = ActiveRecord::Base.transaction do
+    attrs.empty? || clip.update(attrs) and reconcile_taggings(clip, tag_ids)
+  end
+
+  if ok
+    render json: text_clip_json(clip.reload, @current_user, session)
+  else
+    render json: clip.errors, status: :bad_request
+  end
+end
+
+private
+
+def reconcile_taggings(clip, requested_tag_ids)
+  return true if requested_tag_ids.nil?
+
+  allowed_ids = @current_user.clip_tags.active.where(id: requested_tag_ids).pluck(:id)
+  current_active = clip.text_clip_taggings.active
+
+  to_remove = current_active.where.not(clip_tag_id: allowed_ids)
+  to_remove.find_each(&:destroy)
+
+  allowed_ids.each do |tag_id|
+    existing = clip.text_clip_taggings.where(clip_tag_id: tag_id).first
+    if existing
+      existing.update!(workflow_state: "active") unless existing.active?
+    else
+      clip.text_clip_taggings.create!(clip_tag_id: tag_id)
+    end
+  end
+  true
+end
+```
+
+### 5. Routes
+
+Inside the existing `ApiRouteSet::V1.draw` block:
+
+```ruby
+scope(controller: :clip_tags) do
+  get    "users/:user_id/clip_tags",     action: :index,   as: :user_clip_tags
+  post   "users/:user_id/clip_tags",     action: :create
+  put    "users/:user_id/clip_tags/:id", action: :update
+  delete "users/:user_id/clip_tags/:id", action: :destroy
+end
+```
+
+`user_id` accepts `"self"` per Canvas convention; the controller ignores it and uses `@current_user`.
+
+## Frontend (TypeScript / React)
+
+### 6. API + types — `ui/features/text_clips/{api.ts,types.ts}`
+
+```ts
+export type ClipTagColor =
+  | 'blue' | 'green' | 'orange' | 'purple' | 'red' | 'gray' | 'yellow' | 'pink'
+
+export type ClipTagRecord = {
+  id: number | string
+  name: string
+  color: ClipTagColor
+  workflow_state: string
+  created_at: string
+  updated_at: string
+}
+
+export type TextClipRecord = {
+  // …existing fields…
+  tags?: Array<{ id: number | string; name: string; color: ClipTagColor }>
+}
+
+export type TextClipUpdate = {
+  content?: string
+  note?: string
+  tag_ids?: Array<number | string>
+}
+```
+
+New wrappers:
+
+```ts
+fetchClipTags(): Promise<ClipTagRecord[]>
+createClipTag(body: { name: string; color: ClipTagColor }): Promise<ClipTagRecord>
+updateClipTag(id, body: Partial<{ name: string; color: ClipTagColor }>): Promise<ClipTagRecord>
+deleteClipTag(id): Promise<void>
+```
+
+`textClipsIndexPath` gains `opts.tagIds?: Array<number|string>` which serializes as repeated `tag_ids[]=` params.
+
+### 7. Tray — `TextClipsTray.tsx`
+
+Composition in render order (top → bottom):
+
+1. **Tag filter row** — horizontally scrollable strip of `Tag`/`Pill` chips for the current user's `clip_tags`. Selected chips highlight (via filled variant); a small "Clear" `Button` appears when any are selected. Selection is local state (`selectedTagIds: Set<number|string>`) fed into the `useInfiniteQuery` key, so changing tags refetches.
+2. **Search input** — unchanged.
+3. **Undo alert** — unchanged.
+4. **Manage tags panel (collapsed by default)** — opened by a small "Manage tags" `Button` next to "Load more" or under the filter row. Lists all tags with rename (inline `TextInput`) and delete (`IconButton`). Add-tag affordance: an inline `TextInput` + color swatch row + `Create` button. Uses `useMutation` for each verb and invalidates `['clip_tags', userId]`.
+5. **Clip list** — per item, render `clip.tags` as small colored `Tag` chips below the content/note. In the **inline editor**, add a multi-select chip picker that toggles tag ids in the draft; Save sends the new `tag_ids` array along with `content`/`note`.
+
+Tag chip color: derive from the same fixed palette (e.g., `palette[clip.tags[i].color]` → InstUI Tag variant or inline style). Keep it simple: a small object that maps palette name → InstUI `Tag` `themeOverride` or a CSS class.
+
+State summary in the tray:
+
+```ts
+const [selectedTagIds, setSelectedTagIds] = useState<Set<number | string>>(new Set())
+const [manageOpen, setManageOpen] = useState(false)
+const [editDraft, setEditDraft] = useState<{
+  content: string
+  note: string
+  tag_ids: Array<number | string>
+} | null>(null)
+```
+
+The clips query becomes:
+
+```ts
+useInfiniteQuery({
+  queryKey: ['text_clips', courseId, debouncedSearch, Array.from(selectedTagIds).sort()],
+  // …
+  initialPageParam: textClipsIndexPath(courseId, {
+    q: debouncedSearch || undefined,
+    tagIds: Array.from(selectedTagIds),
+  }),
+})
+```
+
+A new `useQuery({ queryKey: ['clip_tags'], queryFn: fetchClipTags })` powers the filter row, the manage panel, and the editor picker.
+
+### 8. Selection clip button (out of scope this slice)
+
+`ui/features/text_clips/index.tsx` does **not** change — newly clipped text still posts without tags. The user tags later through the tray's edit view. This keeps the selection UX latency-free and avoids forcing a tag picker at the moment of clipping.
+
+## Tests
+
+**Models**
+
+- `spec/models/clip_tag_spec.rb` — presence/length of `name`, color inclusion, per-user name uniqueness (case-insensitive, active-only), root_account resolves through user, `for_user` scope, soft-delete behavior, `belongs_to :user`.
+- `spec/models/text_clip_tagging_spec.rb` — unique active tagging per (clip, tag), root_account resolves through text_clip, soft-delete behavior.
+- Extend `spec/models/text_clip_spec.rb` — `with_any_tag([id])` filters; `with_any_tag([])` is a no-op; `clip_tags` association returns only active tags.
+
+**Controllers**
+
+- `spec/controllers/clip_tags_controller_spec.rb` — full CRUD: cross-user 404; 422 on duplicate name; 422 on bad color; soft-delete on destroy.
+- Extend `spec/controllers/text_clips_controller_spec.rb`:
+  - `#index` with `tag_ids[]=`: returns only clips with that tag; multiple `tag_ids[]` = OR.
+  - `#index` serializes `tags` array on each clip.
+  - `#update` with `tag_ids: [a, b]` replaces taggings; passing `[]` removes all; tags belonging to another user are silently ignored.
+  - `#update` is transactional: a content validation failure does not partially update taggings.
+
+**Frontend**
+
+- `ui/features/text_clips/__tests__/api.test.ts` — wrappers for clip_tags CRUD; `updateTextClip` includes `tag_ids`; `textClipsIndexPath` serializes `tag_ids[]`.
+- `ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx`:
+  - Tag chips render under a clip with matching colors.
+  - Clicking a filter chip triggers a refetch with `tag_ids[]=` in the URL; Clear resets it.
+  - Editor tag picker toggles a tag → Save fires `PUT` with the new `tag_ids` array.
+  - Manage panel: create produces a POST; delete soft-deletes and removes from the filter row on refetch; rename updates label.
+
+## Manual verification checklist
+
+- [ ] Create a tag in the manage panel; it appears in the filter row and the editor picker.
+- [ ] Tag a clip via the editor; chip appears under the clip content; row remains in the tray.
+- [ ] Filter by that tag; only matching clips show.
+- [ ] Filter by two tags; clips having either show (OR).
+- [ ] Untag a clip in the editor; chip disappears; if filter was active, clip may leave the list.
+- [ ] Rename a tag; chips on all affected clips update on next refetch.
+- [ ] Delete a tag; chips disappear from affected clips; filter chip is gone; `with_any_tag([deleted_id])` returns 0 clips on next fetch.
+- [ ] Cross-user safety: attempt to apply another user's tag id via `PUT /text_clips/:id` — server silently strips it.
+- [ ] Combined filter + search: only clips matching both the search text and at least one selected tag appear.
+
+## Build / run
+
+Use the [canvas-native-rspec](../skills/canvas-native-rspec/SKILL.md) skill for host RSpec. Otherwise:
+
+```
+docker compose run --rm web bundle exec rails db:migrate
+docker compose run --rm web bin/rspec \
+  spec/models/clip_tag_spec.rb \
+  spec/models/text_clip_tagging_spec.rb \
+  spec/models/text_clip_spec.rb \
+  spec/controllers/clip_tags_controller_spec.rb \
+  spec/controllers/text_clips_controller_spec.rb
+yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+yarn check:ts
+bin/rubocop app/models/clip_tag.rb app/models/text_clip_tagging.rb app/models/text_clip.rb \
+            app/controllers/clip_tags_controller.rb app/controllers/text_clips_controller.rb \
+            lib/api/v1/clip_tag.rb lib/api/v1/text_clip.rb \
+            db/migrate/*_create_clip_tags.rb db/migrate/*_create_text_clip_taggings.rb
+```
+
+## Out of scope (deferred to Slice 5+)
+
+- **Global (course-less) clips view** — the column is already nullable; surface a top-level "All clips" tray entry next slice.
+- **Sharing** clips between users.
+- **Bulk operations** — delete-many, tag-many, undo-many.
+- **Highlight-restoration** — navigating to `source_url` and re-highlighting the clipped text.
+- **Smart suggestions** — auto-tagging based on URL or course.
+- **Tag drag-to-reorder** in the filter row.
+- **Custom colors** outside the fixed palette.

--- a/app/controllers/clip_tags_controller.rb
+++ b/app/controllers/clip_tags_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# @API Clip tags
+#
+# Personal tags for organizing text clips (per-user, cross-course).
+#
+class ClipTagsController < ApplicationController
+  include Api::V1::ClipTag
+
+  before_action :require_user
+
+  def index
+    tags = @current_user.clip_tags.active.order(:name)
+    paginated = Api.paginate(tags, self, api_v1_user_clip_tags_url("self"))
+    render json: clip_tags_json(paginated, @current_user, session)
+  end
+
+  def create
+    tag = @current_user.clip_tags.build(create_params.merge(root_account_id: @domain_root_account.id))
+    if tag.save
+      render json: clip_tag_json(tag, @current_user, session), status: :created
+    else
+      render json: tag.errors, status: :unprocessable_content
+    end
+  end
+
+  def update
+    tag = find_for_current_user(active: true)
+    return unless tag.is_a?(ClipTag)
+
+    if tag.update(update_params)
+      render json: clip_tag_json(tag, @current_user, session)
+    else
+      render json: tag.errors, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    tag = find_for_current_user(active: true)
+    return unless tag.is_a?(ClipTag)
+
+    tag.destroy
+    render json: clip_tag_json(tag, @current_user, session)
+  end
+
+  private
+
+  def find_for_current_user(active:)
+    scope = @current_user.clip_tags
+    scope = scope.active if active
+    scope.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { errors: [{ message: "not found" }] }, status: :not_found
+    nil
+  end
+
+  def create_params
+    params.permit(:name, :color)
+  end
+
+  def update_params
+    params.permit(:name, :color)
+  end
+end

--- a/app/controllers/text_clips_controller.rb
+++ b/app/controllers/text_clips_controller.rb
@@ -41,11 +41,15 @@ class TextClipsController < ApplicationController
                     status: :unprocessable_content
     end
 
+    tag_ids = Array(params[:tag_ids]).map(&:to_i).reject(&:zero?)
+
     clips = @context.shard.activate do
       @current_user.text_clips
                    .active
                    .for_course(@context)
                    .searchable(q)
+                   .with_any_tag(tag_ids)
+                   .preload(:clip_tags)
                    .order(created_at: :desc)
     end
     paginated = Api.paginate(clips, self, api_v1_course_text_clips_url(@context))
@@ -86,8 +90,20 @@ class TextClipsController < ApplicationController
     clip = find_clip_for_current_user(active: true)
     return unless clip.is_a?(TextClip)
 
-    updated = @context.shard.activate { clip.update(normalized_update_params) }
-    if updated
+    permitted = update_params.to_h
+    tag_ids = if permitted.key?("tag_ids")
+                Array(permitted["tag_ids"]).map(&:to_i).reject(&:zero?)
+              end
+    attrs = normalized_update_params(permitted.except("tag_ids"))
+
+    ok = @context.shard.activate do
+      ActiveRecord::Base.transaction do
+        (attrs.empty? || clip.update(attrs)) && sync_clip_taggings(clip, tag_ids)
+      end
+    end
+
+    if ok
+      clip = @context.shard.activate { TextClip.preload(:clip_tags).find(clip.id) }
       render json: text_clip_json(clip, @current_user, session)
     else
       render json: clip.errors, status: :bad_request
@@ -135,12 +151,31 @@ class TextClipsController < ApplicationController
   end
 
   def update_params
-    params.permit(:content, :note)
+    params.permit(:content, :note, tag_ids: [])
   end
 
-  def normalized_update_params
-    attrs = update_params.to_h.symbolize_keys
+  def normalized_update_params(permitted = nil)
+    attrs = (permitted || update_params.to_h).symbolize_keys
     attrs[:note] = attrs[:note].presence if attrs.key?(:note)
     attrs
+  end
+
+  def sync_clip_taggings(clip, requested_tag_ids)
+    return true if requested_tag_ids.nil?
+
+    allowed_ids = @current_user.clip_tags.active.where(id: requested_tag_ids).pluck(:id)
+    current_active = clip.text_clip_taggings.active
+
+    to_remove = current_active.where.not(clip_tag_id: allowed_ids)
+    to_remove.find_each(&:destroy)
+
+    allowed_ids.each do |tag_id|
+      existing = clip.text_clip_taggings.where(clip_tag_id: tag_id).first
+      if existing
+        existing.update!(workflow_state: "active") unless existing.active?
+      else
+        clip.text_clip_taggings.create!(clip_tag_id: tag_id)
+      end
+    end
   end
 end

--- a/app/models/clip_tag.rb
+++ b/app/models/clip_tag.rb
@@ -17,21 +17,22 @@
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+class ClipTag < ApplicationRecord
+  extend RootAccountResolver
+  include Canvas::SoftDeletable
 
-module Api::V1::TextClip
-  include Api::V1::Json
+  PALETTE = %w[blue green orange purple red gray yellow pink].freeze
 
-  API_JSON_OPTS = {
-    only: %w[id content source_url source_title note user_id course_id workflow_state created_at updated_at]
-  }.freeze
+  belongs_to :user
+  has_many :text_clip_taggings, dependent: :destroy
+  has_many :text_clips, through: :text_clip_taggings
 
-  def text_clip_json(clip, user, session, opts = {})
-    json = api_json(clip, user, session, opts.merge(API_JSON_OPTS))
-    json["tags"] = clip.clip_tags.map { |t| { "id" => t.id, "name" => t.name, "color" => t.color } }
-    json
-  end
+  resolves_root_account through: :user
 
-  def text_clips_json(clips, user, session, opts = {})
-    clips.map { |c| text_clip_json(c, user, session, opts) }
-  end
+  validates :name, presence: true, length: { maximum: 64 }
+  validates :color, inclusion: { in: PALETTE }
+  validates :workflow_state, presence: true
+  validates :name, uniqueness: { scope: :user_id, conditions: -> { active }, case_sensitive: false }
+
+  scope :for_user, ->(user) { where(user:) }
 end

--- a/app/models/text_clip.rb
+++ b/app/models/text_clip.rb
@@ -23,6 +23,9 @@ class TextClip < ApplicationRecord
 
   belongs_to :user
   belongs_to :course, optional: true
+  has_many :text_clip_taggings, dependent: :destroy
+  has_many :active_text_clip_taggings, -> { active }, class_name: "TextClipTagging"
+  has_many :clip_tags, -> { active }, through: :active_text_clip_taggings, source: :clip_tag
 
   resolves_root_account through: :course
 
@@ -40,5 +43,12 @@ class TextClip < ApplicationRecord
 
     pattern = "%#{sanitize_sql_like(q)}%"
     where("content ILIKE :p OR source_title ILIKE :p OR note ILIKE :p", p: pattern)
+  }
+  scope :with_any_tag, lambda { |tag_ids|
+    next all if Array(tag_ids).compact.blank?
+
+    joins(:text_clip_taggings)
+      .where(text_clip_taggings: { clip_tag_id: tag_ids, workflow_state: "active" })
+      .distinct
   }
 end

--- a/app/models/text_clip_tagging.rb
+++ b/app/models/text_clip_tagging.rb
@@ -17,21 +17,19 @@
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+class TextClipTagging < ApplicationRecord
+  extend RootAccountResolver
+  include Canvas::SoftDeletable
 
-module Api::V1::TextClip
-  include Api::V1::Json
+  belongs_to :text_clip
+  belongs_to :clip_tag
 
-  API_JSON_OPTS = {
-    only: %w[id content source_url source_title note user_id course_id workflow_state created_at updated_at]
-  }.freeze
+  resolves_root_account through: :text_clip
 
-  def text_clip_json(clip, user, session, opts = {})
-    json = api_json(clip, user, session, opts.merge(API_JSON_OPTS))
-    json["tags"] = clip.clip_tags.map { |t| { "id" => t.id, "name" => t.name, "color" => t.color } }
-    json
-  end
-
-  def text_clips_json(clips, user, session, opts = {})
-    clips.map { |c| text_clip_json(c, user, session, opts) }
-  end
+  validates :workflow_state, presence: true
+  validates :clip_tag_id, uniqueness: {
+    scope: :text_clip_id,
+    conditions: -> { active },
+    case_sensitive: false
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,7 @@ class User < ApplicationRecord
   has_many :ignores
   has_many :planner_notes, dependent: :destroy
   has_many :text_clips, dependent: :destroy, multishard: true
+  has_many :clip_tags, dependent: :destroy, multishard: true
   has_many :viewed_submission_comments, dependent: :destroy
 
   has_many :enrollments, dependent: :destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2893,6 +2893,13 @@ CanvasRails::Application.routes.draw do
       post "courses/:course_id/text_clips/:id/undestroy", action: :undestroy, as: :undestroy_course_text_clip
     end
 
+    scope(controller: :clip_tags) do
+      get "users/:user_id/clip_tags", action: :index, as: :user_clip_tags
+      post "users/:user_id/clip_tags", action: :create
+      put "users/:user_id/clip_tags/:id", action: :update
+      delete "users/:user_id/clip_tags/:id", action: :destroy
+    end
+
     scope(controller: :content_shares) do
       post "users/:user_id/content_shares", action: :create
       get "users/:user_id/content_shares/sent", action: :index, defaults: { list: "sent" }, as: :user_sent_content_shares

--- a/db/migrate/20260526120000_create_clip_tags.rb
+++ b/db/migrate/20260526120000_create_clip_tags.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+class CreateClipTags < ActiveRecord::Migration[8.0]
+  tag :predeploy
+
+  def change
+    create_table :clip_tags do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false, limit: 64
+      t.string :color, null: false, default: "blue", limit: 32
+      t.string :workflow_state, null: false, default: "active", limit: 255
+      t.references :root_account, null: false, foreign_key: { to_table: :accounts }, index: false
+      t.timestamps
+
+      t.check_constraint "workflow_state IN ('active', 'deleted')", name: "chk_clip_tags_workflow_state_enum"
+      t.replica_identity_index
+      t.index "user_id, LOWER(name)",
+              unique: true,
+              where: "workflow_state = 'active'",
+              name: "index_clip_tags_on_user_id_lower_name_active"
+    end
+  end
+end

--- a/db/migrate/20260526120001_create_text_clip_taggings.rb
+++ b/db/migrate/20260526120001_create_text_clip_taggings.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+class CreateTextClipTaggings < ActiveRecord::Migration[8.0]
+  tag :predeploy
+
+  def change
+    create_table :text_clip_taggings do |t|
+      t.references :text_clip, null: false, foreign_key: true
+      t.references :clip_tag, null: false, foreign_key: true
+      t.references :root_account, null: false, foreign_key: { to_table: :accounts }, index: false
+      t.string :workflow_state, null: false, default: "active", limit: 255
+      t.timestamps
+
+      t.check_constraint "workflow_state IN ('active', 'deleted')", name: "chk_text_clip_taggings_workflow_state_enum"
+      t.replica_identity_index
+      t.index %i[text_clip_id clip_tag_id],
+              unique: true,
+              where: "workflow_state = 'active'",
+              name: "index_text_clip_taggings_unique_active"
+    end
+  end
+end

--- a/lib/api/v1/clip_tag.rb
+++ b/lib/api/v1/clip_tag.rb
@@ -18,20 +18,18 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-module Api::V1::TextClip
+module Api::V1::ClipTag
   include Api::V1::Json
 
   API_JSON_OPTS = {
-    only: %w[id content source_url source_title note user_id course_id workflow_state created_at updated_at]
+    only: %w[id name color workflow_state created_at updated_at]
   }.freeze
 
-  def text_clip_json(clip, user, session, opts = {})
-    json = api_json(clip, user, session, opts.merge(API_JSON_OPTS))
-    json["tags"] = clip.clip_tags.map { |t| { "id" => t.id, "name" => t.name, "color" => t.color } }
-    json
+  def clip_tag_json(tag, user, session, opts = {})
+    api_json(tag, user, session, opts.merge(API_JSON_OPTS))
   end
 
-  def text_clips_json(clips, user, session, opts = {})
-    clips.map { |c| text_clip_json(c, user, session, opts) }
+  def clip_tags_json(tags, user, session, opts = {})
+    tags.map { |t| clip_tag_json(t, user, session, opts) }
   end
 end

--- a/spec/controllers/clip_tags_controller_spec.rb
+++ b/spec/controllers/clip_tags_controller_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe ClipTagsController do
+  before :once do
+    course_with_teacher_and_student_enrolled(active_all: true)
+    @teacher_tag = ClipTag.create!(
+      user_id: @teacher.id,
+      name: "Teacher tag",
+      color: "blue",
+      root_account_id: @course.root_account_id
+    )
+    @student_tag = ClipTag.create!(
+      user_id: @student.id,
+      name: "Student tag",
+      color: "green",
+      root_account_id: @course.root_account_id
+    )
+  end
+
+  context "unauthenticated" do
+    it "returns unauthorized for index" do
+      get :index, format: :json, params: { user_id: "self" }
+      assert_unauthorized
+    end
+  end
+
+  context "authenticated as teacher" do
+    before do
+      user_session(@teacher)
+    end
+
+    describe "GET #index" do
+      it "returns only the current user's tags ordered by name" do
+        get :index, format: :json, params: { user_id: "self" }
+        expect(response).to be_successful
+        body = json_parse(response.body)
+        expect(body.pluck("id")).to eq [@teacher_tag.id]
+        expect(body.pluck("name")).to eq ["Teacher tag"]
+      end
+    end
+
+    describe "POST #create" do
+      it "creates a tag for the current user" do
+        post :create, format: :json, params: { user_id: "self", name: "New tag", color: "orange" }
+        expect(response).to have_http_status(:created)
+        body = json_parse(response.body)
+        tag = ClipTag.find(body["id"])
+        expect(tag.user_id).to eq @teacher.id
+        expect(tag.name).to eql "New tag"
+        expect(tag.color).to eql "orange"
+      end
+
+      it "returns 422 on duplicate name" do
+        post :create, format: :json, params: { user_id: "self", name: "Teacher tag", color: "red" }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "returns 422 on invalid color" do
+        post :create, format: :json, params: { user_id: "self", name: "Bad color", color: "neon" }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    describe "PUT #update" do
+      it "renames the current user's tag" do
+        put :update, format: :json, params: { user_id: "self", id: @teacher_tag.id, name: "Renamed" }
+        expect(response).to be_successful
+        expect(@teacher_tag.reload.name).to eql "Renamed"
+      end
+
+      it "returns not found for another user's tag" do
+        put :update, format: :json, params: { user_id: "self", id: @student_tag.id, name: "Hacked" }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "DELETE #destroy" do
+      it "soft-deletes the current user's tag" do
+        delete :destroy, format: :json, params: { user_id: "self", id: @teacher_tag.id }
+        expect(response).to be_successful
+        expect(@teacher_tag.reload.workflow_state).to eql "deleted"
+      end
+
+      it "returns not found for another user's tag" do
+        delete :destroy, format: :json, params: { user_id: "self", id: @student_tag.id }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/controllers/text_clips_controller_spec.rb
+++ b/spec/controllers/text_clips_controller_spec.rb
@@ -96,6 +96,52 @@ describe TextClipsController do
         get :index, format: :json, params: { course_id: @course.id, q: "a" }
         expect(response).to have_http_status(:unprocessable_content)
       end
+
+      it "filters clips by tag_ids (OR)" do
+        tag_a = ClipTag.create!(
+          user_id: @teacher.id,
+          name: "Filter A",
+          color: "blue",
+          root_account_id: @course.root_account_id
+        )
+        tag_b = ClipTag.create!(
+          user_id: @teacher.id,
+          name: "Filter B",
+          color: "green",
+          root_account_id: @course.root_account_id
+        )
+        tagged_a = create_clip_for(@teacher, @course, "Clip with A")
+        tagged_b = create_clip_for(@teacher, @course, "Clip with B")
+        @course.shard.activate do
+          TextClipTagging.create!(text_clip: tagged_a, clip_tag: tag_a, root_account_id: @course.root_account_id)
+          TextClipTagging.create!(text_clip: tagged_b, clip_tag: tag_b, root_account_id: @course.root_account_id)
+        end
+
+        get :index, format: :json, params: { course_id: @course.id, tag_ids: [tag_a.id] }
+        expect(json_parse(response.body).pluck("id")).to eq [tagged_a.id]
+
+        get :index, format: :json, params: { course_id: @course.id, tag_ids: [tag_a.id, tag_b.id] }
+        expect(json_parse(response.body).pluck("id")).to contain_exactly(tagged_a.id, tagged_b.id)
+      end
+
+      it "serializes tags on each clip" do
+        tag = ClipTag.create!(
+          user_id: @teacher.id,
+          name: "Serialized",
+          color: "purple",
+          root_account_id: @course.root_account_id
+        )
+        @course.shard.activate do
+          TextClipTagging.create!(
+            text_clip: @teacher_clip,
+            clip_tag: tag,
+            root_account_id: @course.root_account_id
+          )
+        end
+        get :index, format: :json, params: { course_id: @course.id }
+        body = json_parse(response.body).find { |c| c["id"] == @teacher_clip.id }
+        expect(body["tags"]).to eq [{ "id" => tag.id, "name" => "Serialized", "color" => "purple" }]
+      end
     end
 
     describe "POST #create" do
@@ -179,6 +225,116 @@ describe TextClipsController do
           content: ""
         }
         expect(response).to have_http_status(:bad_request)
+      end
+
+      it "replaces taggings idempotently via tag_ids" do
+        tag_a = ClipTag.create!(
+          user_id: @teacher.id,
+          name: "Tag A",
+          color: "blue",
+          root_account_id: @course.root_account_id
+        )
+        tag_b = ClipTag.create!(
+          user_id: @teacher.id,
+          name: "Tag B",
+          color: "green",
+          root_account_id: @course.root_account_id
+        )
+        @course.shard.activate do
+          TextClipTagging.create!(
+            text_clip: @teacher_clip,
+            clip_tag: tag_a,
+            root_account_id: @course.root_account_id
+          )
+        end
+
+        put :update, format: :json, params: {
+          course_id: @course.id,
+          id: @teacher_clip.id,
+          tag_ids: [tag_b.id]
+        }
+        expect(response).to be_successful
+        body = json_parse(response.body)
+        expect(body["tags"].pluck("id")).to eq [tag_b.id]
+        active_tag_ids = @course.shard.activate do
+          @teacher_clip.reload.text_clip_taggings.active.pluck(:clip_tag_id)
+        end
+        expect(active_tag_ids).to eq [tag_b.id]
+      end
+
+      it "removes all taggings when tag_ids is empty" do
+        tag = ClipTag.create!(
+          user_id: @teacher.id,
+          name: "Removable",
+          color: "red",
+          root_account_id: @course.root_account_id
+        )
+        @course.shard.activate do
+          TextClipTagging.create!(
+            text_clip: @teacher_clip,
+            clip_tag: tag,
+            root_account_id: @course.root_account_id
+          )
+        end
+
+        put :update, as: :json, params: {
+          course_id: @course.id,
+          id: @teacher_clip.id,
+          tag_ids: []
+        }
+        expect(response).to be_successful
+        expect(json_parse(response.body)["tags"]).to eq []
+      end
+
+      it "silently ignores another user's tag ids" do
+        other_tag = ClipTag.create!(
+          user_id: @student.id,
+          name: "Student only",
+          color: "gray",
+          root_account_id: @course.root_account_id
+        )
+        own_tag = ClipTag.create!(
+          user_id: @teacher.id,
+          name: "Teacher own",
+          color: "yellow",
+          root_account_id: @course.root_account_id
+        )
+
+        put :update, format: :json, params: {
+          course_id: @course.id,
+          id: @teacher_clip.id,
+          tag_ids: [other_tag.id, own_tag.id]
+        }
+        expect(response).to be_successful
+        expect(json_parse(response.body)["tags"].pluck("id")).to eq [own_tag.id]
+      end
+
+      it "does not partially update taggings when content validation fails" do
+        tag = ClipTag.create!(
+          user_id: @teacher.id,
+          name: "Stays",
+          color: "pink",
+          root_account_id: @course.root_account_id
+        )
+        @course.shard.activate do
+          TextClipTagging.create!(
+            text_clip: @teacher_clip,
+            clip_tag: tag,
+            root_account_id: @course.root_account_id
+          )
+        end
+
+        put :update, format: :json, params: {
+          course_id: @course.id,
+          id: @teacher_clip.id,
+          content: "",
+          tag_ids: []
+        }
+        expect(response).to have_http_status(:bad_request)
+        active_count = @course.shard.activate do
+          @teacher_clip.reload.text_clip_taggings.active.count
+        end
+        expect(active_count).to eq 1
       end
     end
 

--- a/spec/models/clip_tag_spec.rb
+++ b/spec/models/clip_tag_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe ClipTag do
+  before :once do
+    course_with_student(active_all: true)
+  end
+
+  def build_tag(attrs = {})
+    ClipTag.new({
+      user: @student,
+      name: "Important",
+      color: "blue",
+      root_account_id: @course.root_account_id
+    }.merge(attrs))
+  end
+
+  it "saves with valid attributes" do
+    tag = build_tag
+    expect(tag.save).to be true
+    expect(tag.workflow_state).to eql "active"
+  end
+
+  it "requires name" do
+    tag = build_tag(name: "")
+    expect(tag).not_to be_valid
+    expect(tag.errors[:name]).to be_present
+  end
+
+  it "rejects names over 64 characters" do
+    tag = build_tag(name: "x" * 65)
+    expect(tag).not_to be_valid
+    expect(tag.errors[:name]).to be_present
+  end
+
+  it "rejects colors outside the palette" do
+    tag = build_tag(color: "chartreuse")
+    expect(tag).not_to be_valid
+    expect(tag.errors[:color]).to be_present
+  end
+
+  it "enforces per-user name uniqueness case-insensitively among active tags" do
+    build_tag.save!
+    duplicate = build_tag(name: "important")
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:name]).to be_present
+  end
+
+  it "allows the same name after the prior tag is soft-deleted" do
+    tag = build_tag
+    tag.save!
+    tag.destroy
+    replacement = build_tag(name: "Important")
+    expect(replacement).to be_valid
+  end
+
+  describe ".for_user" do
+    it "returns only tags for the given user" do
+      student_tag = build_tag
+      student_tag.save!
+      teacher_tag = build_tag(user: @teacher, name: "Teacher tag")
+      teacher_tag.save!
+
+      expect(ClipTag.for_user(@student).order(:id)).to eq [student_tag]
+    end
+  end
+
+  describe "soft delete" do
+    it "marks workflow_state deleted without removing the record" do
+      tag = build_tag
+      tag.save!
+      tag.destroy
+      tag.reload
+      expect(tag.workflow_state).to eql "deleted"
+      expect(ClipTag.find(tag.id)).to eql tag
+    end
+  end
+end

--- a/spec/models/text_clip_spec.rb
+++ b/spec/models/text_clip_spec.rb
@@ -160,4 +160,77 @@ describe TextClip do
       expect(TextClip.for_course(@course).order(:id)).to eq [@student_clip, @teacher_clip]
     end
   end
+
+  describe ".with_any_tag" do
+    before :once do
+      @tag_a = ClipTag.create!(
+        user_id: @student.id,
+        name: "Tag A",
+        color: "blue",
+        root_account_id: @course.root_account_id
+      )
+      @tag_b = ClipTag.create!(
+        user_id: @student.id,
+        name: "Tag B",
+        color: "green",
+        root_account_id: @course.root_account_id
+      )
+      @tagged_a = TextClip.create!(
+        user_id: @student.id,
+        course_id: @course.id,
+        content: "Has tag A",
+        root_account_id: @course.root_account_id
+      )
+      TextClipTagging.create!(
+        text_clip: @tagged_a,
+        clip_tag: @tag_a,
+        root_account_id: @course.root_account_id
+      )
+      @tagged_b = TextClip.create!(
+        user_id: @student.id,
+        course_id: @course.id,
+        content: "Has tag B",
+        root_account_id: @course.root_account_id
+      )
+      TextClipTagging.create!(
+        text_clip: @tagged_b,
+        clip_tag: @tag_b,
+        root_account_id: @course.root_account_id
+      )
+    end
+
+    it "returns all clips when tag_ids is empty" do
+      expect(TextClip.with_any_tag([]).order(:id)).to eq TextClip.order(:id).to_a
+    end
+
+    it "filters to clips with the given tag" do
+      expect(TextClip.with_any_tag([@tag_a.id]).order(:id)).to eq [@tagged_a]
+    end
+
+    it "matches any of multiple tag ids (OR)" do
+      expect(TextClip.with_any_tag([@tag_a.id, @tag_b.id]).order(:id)).to eq [@tagged_a, @tagged_b]
+    end
+  end
+
+  describe "clip_tags association" do
+    it "returns only active tags through active taggings" do
+      tag = ClipTag.create!(
+        user_id: @student.id,
+        name: "Active tag",
+        color: "purple",
+        root_account_id: @course.root_account_id
+      )
+      tagging = TextClipTagging.create!(
+        text_clip: @student_clip,
+        clip_tag: tag,
+        root_account_id: @course.root_account_id
+      )
+      expect(@student_clip.clip_tags).to eq [tag]
+
+      tagging.destroy
+      tag.destroy
+      @student_clip.reload
+      expect(@student_clip.clip_tags).to eq []
+    end
+  end
 end

--- a/spec/models/text_clip_tagging_spec.rb
+++ b/spec/models/text_clip_tagging_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe TextClipTagging do
+  before :once do
+    course_with_student(active_all: true)
+    @clip = TextClip.create!(
+      user_id: @student.id,
+      course_id: @course.id,
+      content: "Tagged clip",
+      root_account_id: @course.root_account_id
+    )
+    @tag = ClipTag.create!(
+      user_id: @student.id,
+      name: "Exam",
+      color: "orange",
+      root_account_id: @course.root_account_id
+    )
+  end
+
+  def build_tagging(attrs = {})
+    TextClipTagging.new({
+      text_clip: @clip,
+      clip_tag: @tag,
+      root_account_id: @course.root_account_id
+    }.merge(attrs))
+  end
+
+  it "saves a valid tagging" do
+    tagging = build_tagging
+    expect(tagging.save).to be true
+    expect(tagging.root_account_id).to eq @course.root_account_id
+  end
+
+  it "rejects duplicate active taggings for the same clip and tag" do
+    build_tagging.save!
+    duplicate = build_tagging
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:clip_tag_id]).to be_present
+  end
+
+  it "allows re-tagging after soft-delete" do
+    tagging = build_tagging
+    tagging.save!
+    tagging.destroy
+    replacement = build_tagging
+    expect(replacement).to be_valid
+  end
+
+  describe "soft delete" do
+    it "marks workflow_state deleted without removing the record" do
+      tagging = build_tagging
+      tagging.save!
+      tagging.destroy
+      tagging.reload
+      expect(tagging.workflow_state).to eql "deleted"
+    end
+  end
+end

--- a/ui/features/navigation_header/react/trays/TextClipsTray.tsx
+++ b/ui/features/navigation_header/react/trays/TextClipsTray.tsx
@@ -19,33 +19,73 @@
 import {useScope as createI18nScope} from '@canvas/i18n'
 import {Alert} from '@instructure/ui-alerts'
 import {Button, IconButton} from '@instructure/ui-buttons'
+import {Flex} from '@instructure/ui-flex'
 import {Heading} from '@instructure/ui-heading'
 import {IconEditLine, IconExternalLinkLine, IconTrashLine} from '@instructure/ui-icons'
 import {Link} from '@instructure/ui-link'
 import {List} from '@instructure/ui-list'
 import {showFlashAlert} from '@instructure/platform-alerts'
 import {Spinner} from '@instructure/ui-spinner'
+import {Tag} from '@instructure/ui-tag'
 import {Text} from '@instructure/ui-text'
 import {TextArea} from '@instructure/ui-text-area'
 import {TextInput} from '@instructure/ui-text-input'
 import {View} from '@instructure/ui-view'
-import React, {useEffect, useMemo, useState} from 'react'
-import {useInfiniteQuery, useMutation, useQueryClient} from '@tanstack/react-query'
+import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import {useInfiniteQuery, useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {
+  createClipTag,
+  deleteClipTag,
   deleteTextClip,
+  fetchClipTags,
   fetchTextClipsPage,
   textClipsIndexPath,
   undeleteTextClip,
+  updateClipTag,
   updateTextClip,
 } from '../../../text_clips/api'
-import type {TextClipRecord, TextClipUpdate} from '../../../text_clips/types'
+import {CLIP_TAG_PALETTE, CLIP_TAG_THEME} from '../../../text_clips/tagColors'
+import type {
+  ClipTagColor,
+  ClipTagRecord,
+  TextClipRecord,
+  TextClipTagStub,
+  TextClipUpdate,
+} from '../../../text_clips/types'
 
 const I18n = createI18nScope('text_clips')
 const SEARCH_DEBOUNCE_MS = 250
 const UNDO_TIMEOUT_MS = 8000
 
-type EditDraft = {content: string; note: string}
+type EditDraft = {content: string; note: string; tag_ids: Array<number | string>}
 type PendingUndo = {id: number | string; preview: string}
+
+function ClipTagChip({
+  tag,
+  selected,
+  onClick,
+  testId,
+}: {
+  tag: TextClipTagStub | ClipTagRecord
+  selected?: boolean
+  onClick?: () => void
+  testId?: string
+}) {
+  const theme = CLIP_TAG_THEME[tag.color]
+  return (
+    <Tag
+      text={tag.name}
+      margin="0 x-small x-small 0"
+      data-testid={testId}
+      onClick={onClick}
+      themeOverride={{
+        defaultBackground: selected ? theme.borderColor : theme.background,
+        defaultBorderColor: theme.borderColor,
+        defaultColor: selected ? '#FFFFFF' : theme.color,
+      }}
+    />
+  )
+}
 
 function clipPreview(content: string | null | undefined, max = 160) {
   const oneLine = (content ?? '').replace(/\s+/g, ' ').trim()
@@ -71,11 +111,13 @@ type TextClipListItemProps = {
   clip: TextClipRecord
   editingId: number | string | null
   editDraft: EditDraft | null
+  allTags: ClipTagRecord[]
   onStartEdit: (clip: TextClipRecord) => void
   onEditDraftChange: (draft: EditDraft) => void
   onCancelEdit: () => void
   onSaveEdit: (id: number | string, body: TextClipUpdate) => void
   onDelete: (clip: TextClipRecord) => void
+  onToggleEditTag: (tagId: number | string) => void
   isSaving: boolean
   isDeleting: boolean
 }
@@ -84,11 +126,13 @@ function TextClipListItem({
   clip,
   editingId,
   editDraft,
+  allTags,
   onStartEdit,
   onEditDraftChange,
   onCancelEdit,
   onSaveEdit,
   onDelete,
+  onToggleEditTag,
   isSaving,
   isDeleting,
 }: TextClipListItemProps) {
@@ -114,6 +158,22 @@ function TextClipListItem({
               />
             </View>
             <View margin="x-small 0 0 0">
+              <Text as="div" size="small" weight="bold">
+                {I18n.t('Tags')}
+              </Text>
+              <Flex wrap="wrap" margin="xx-small 0 0 0">
+                {allTags.map(tag => (
+                  <ClipTagChip
+                    key={String(tag.id)}
+                    tag={tag}
+                    selected={editDraft.tag_ids.includes(tag.id)}
+                    onClick={() => onToggleEditTag(tag.id)}
+                    testId={`text-clip-edit-tag-${clip.id}-${tag.id}`}
+                  />
+                ))}
+              </Flex>
+            </View>
+            <View margin="x-small 0 0 0">
               <Button
                 size="small"
                 margin="0 x-small 0 0"
@@ -122,6 +182,7 @@ function TextClipListItem({
                   onSaveEdit(clip.id, {
                     content: editDraft.content,
                     note: editDraft.note,
+                    tag_ids: editDraft.tag_ids,
                   })
                 }
                 interaction={isSaving ? 'disabled' : 'enabled'}
@@ -141,6 +202,17 @@ function TextClipListItem({
         ) : (
           <>
             <Text>{clipPreview(clip.content)}</Text>
+            {clip.tags && clip.tags.length > 0 && (
+              <Flex wrap="wrap" margin="xx-small 0 0 0" data-testid={`text-clip-tags-${clip.id}`}>
+                {clip.tags.map(tag => (
+                  <ClipTagChip
+                    key={String(tag.id)}
+                    tag={tag}
+                    testId={`text-clip-tag-${clip.id}-${tag.id}`}
+                  />
+                ))}
+              </Flex>
+            )}
             {clip.note && (
               <View margin="xx-small 0 0 0">
                 <Text
@@ -197,9 +269,15 @@ export default function TextClipsTray() {
   const courseId = window.ENV.COURSE_ID
   const [searchInput, setSearchInput] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [selectedTagIds, setSelectedTagIds] = useState<Set<number | string>>(new Set())
+  const [manageOpen, setManageOpen] = useState(false)
+  const [newTagName, setNewTagName] = useState('')
+  const [newTagColor, setNewTagColor] = useState<ClipTagColor>('blue')
   const [editingId, setEditingId] = useState<number | string | null>(null)
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null)
   const [pendingUndo, setPendingUndo] = useState<PendingUndo | null>(null)
+  const [renamingTagId, setRenamingTagId] = useState<number | string | null>(null)
+  const [renameDraft, setRenameDraft] = useState('')
 
   useEffect(() => {
     const handle = window.setTimeout(() => {
@@ -215,8 +293,18 @@ export default function TextClipsTray() {
   }, [pendingUndo])
 
   const searchTooShort = debouncedSearch.length === 1
+  const selectedTagIdsArray = useMemo(
+    () => Array.from(selectedTagIds).sort((a, b) => String(a).localeCompare(String(b))),
+    [selectedTagIds],
+  )
 
-  const queryKey = ['text_clips', courseId, debouncedSearch] as const
+  const clipTagsQueryKey = ['clip_tags'] as const
+  const {data: clipTags = []} = useQuery({
+    queryKey: clipTagsQueryKey,
+    queryFn: fetchClipTags,
+  })
+
+  const queryKey = ['text_clips', courseId, debouncedSearch, selectedTagIdsArray] as const
 
   const {data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage} =
     useInfiniteQuery({
@@ -225,6 +313,7 @@ export default function TextClipsTray() {
       getNextPageParam: page => page.nextPage ?? undefined,
       initialPageParam: textClipsIndexPath(courseId as string | number, {
         q: debouncedSearch || undefined,
+        tagIds: selectedTagIdsArray.length > 0 ? selectedTagIdsArray : undefined,
       }),
       enabled: Boolean(courseId) && !searchTooShort,
     })
@@ -234,6 +323,66 @@ export default function TextClipsTray() {
   const invalidateClips = () => {
     void queryClient.invalidateQueries({queryKey: ['text_clips', courseId]})
   }
+
+  const invalidateClipTags = () => {
+    void queryClient.invalidateQueries({queryKey: clipTagsQueryKey})
+  }
+
+  const toggleFilterTag = useCallback((tagId: number | string) => {
+    setSelectedTagIds(prev => {
+      const next = new Set(prev)
+      if (next.has(tagId)) {
+        next.delete(tagId)
+      } else {
+        next.add(tagId)
+      }
+      return next
+    })
+  }, [])
+
+  const toggleEditTag = useCallback((tagId: number | string) => {
+    setEditDraft(prev => {
+      if (!prev) return prev
+      const ids = new Set(prev.tag_ids)
+      if (ids.has(tagId)) {
+        ids.delete(tagId)
+      } else {
+        ids.add(tagId)
+      }
+      return {...prev, tag_ids: Array.from(ids)}
+    })
+  }, [])
+
+  const createTagMutation = useMutation({
+    mutationFn: () => createClipTag({name: newTagName.trim(), color: newTagColor}),
+    onSuccess: () => {
+      setNewTagName('')
+      invalidateClipTags()
+    },
+  })
+
+  const updateTagMutation = useMutation({
+    mutationFn: ({id, name}: {id: number | string; name: string}) => updateClipTag(id, {name}),
+    onSuccess: () => {
+      setRenamingTagId(null)
+      setRenameDraft('')
+      invalidateClipTags()
+      invalidateClips()
+    },
+  })
+
+  const deleteTagMutation = useMutation({
+    mutationFn: (id: number | string) => deleteClipTag(id),
+    onSuccess: (_data, id) => {
+      setSelectedTagIds(prev => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+      invalidateClipTags()
+      invalidateClips()
+    },
+  })
 
   useEffect(() => {
     const onCreated = () => {
@@ -281,7 +430,11 @@ export default function TextClipsTray() {
 
   const startEdit = (clip: TextClipRecord) => {
     setEditingId(clip.id)
-    setEditDraft({content: clip.content, note: clip.note ?? ''})
+    setEditDraft({
+      content: clip.content,
+      note: clip.note ?? '',
+      tag_ids: (clip.tags ?? []).map(t => t.id),
+    })
   }
 
   return (
@@ -290,6 +443,145 @@ export default function TextClipsTray() {
         {I18n.t('Text clips')}
       </Heading>
       <hr role="presentation" />
+
+      {clipTags.length > 0 && (
+        <View margin="small 0" data-testid="text-clips-tag-filter">
+          <Flex wrap="no-wrap" alignItems="center">
+            <View as="div" maxWidth="100%" overflowX="auto" overflowY="hidden" display="block">
+              <Flex wrap="no-wrap" alignItems="center">
+                {clipTags.map(tag => (
+                  <ClipTagChip
+                    key={String(tag.id)}
+                    tag={tag}
+                    selected={selectedTagIds.has(tag.id)}
+                    onClick={() => toggleFilterTag(tag.id)}
+                    testId={`text-clips-filter-tag-${tag.id}`}
+                  />
+                ))}
+              </Flex>
+            </View>
+            {selectedTagIds.size > 0 && (
+              <Button
+                size="small"
+                margin="0 0 0 x-small"
+                data-testid="text-clips-clear-filters"
+                onClick={() => setSelectedTagIds(new Set())}
+              >
+                {I18n.t('Clear')}
+              </Button>
+            )}
+          </Flex>
+        </View>
+      )}
+
+      <View margin="small 0">
+        <Button
+          size="small"
+          data-testid="text-clips-manage-tags-toggle"
+          onClick={() => setManageOpen(open => !open)}
+        >
+          {manageOpen ? I18n.t('Hide tags') : I18n.t('Manage tags')}
+        </Button>
+      </View>
+
+      {manageOpen && (
+        <View
+          as="div"
+          margin="small 0"
+          padding="small"
+          borderWidth="small"
+          data-testid="text-clips-manage-tags-panel"
+        >
+          {clipTags.map(tag => (
+            <Flex key={String(tag.id)} alignItems="center" margin="x-small 0">
+              <ClipTagChip tag={tag} />
+              {renamingTagId === tag.id ? (
+                <>
+                  <TextInput
+                    renderLabel={I18n.t('Rename tag')}
+                    display="inline-block"
+                    value={renameDraft}
+                    onChange={(_e, value) => setRenameDraft(value)}
+                    data-testid={`text-clips-rename-input-${tag.id}`}
+                  />
+                  <Button
+                    size="small"
+                    margin="0 x-small"
+                    data-testid={`text-clips-rename-save-${tag.id}`}
+                    onClick={() => updateTagMutation.mutate({id: tag.id, name: renameDraft.trim()})}
+                    interaction={updateTagMutation.isPending ? 'disabled' : 'enabled'}
+                  >
+                    {I18n.t('Save')}
+                  </Button>
+                  <Button
+                    size="small"
+                    onClick={() => {
+                      setRenamingTagId(null)
+                      setRenameDraft('')
+                    }}
+                  >
+                    {I18n.t('Cancel')}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    size="small"
+                    margin="0 x-small"
+                    data-testid={`text-clips-rename-tag-${tag.id}`}
+                    onClick={() => {
+                      setRenamingTagId(tag.id)
+                      setRenameDraft(tag.name)
+                    }}
+                  >
+                    {I18n.t('Rename')}
+                  </Button>
+                  <IconButton
+                    size="small"
+                    screenReaderLabel={I18n.t('Delete tag')}
+                    renderIcon={IconTrashLine}
+                    data-testid={`text-clips-delete-tag-${tag.id}`}
+                    onClick={() => deleteTagMutation.mutate(tag.id)}
+                    interaction={deleteTagMutation.isPending ? 'disabled' : 'enabled'}
+                  />
+                </>
+              )}
+            </Flex>
+          ))}
+          <View margin="small 0 0 0">
+            <TextInput
+              renderLabel={I18n.t('New tag name')}
+              placeholder={I18n.t('New tag')}
+              value={newTagName}
+              onChange={(_e, value) => setNewTagName(value)}
+              data-testid="text-clips-new-tag-name"
+            />
+          </View>
+          <Flex wrap="wrap" margin="x-small 0">
+            {CLIP_TAG_PALETTE.map(color => (
+              <Button
+                key={color}
+                size="small"
+                margin="0 x-small x-small 0"
+                data-testid={`text-clips-new-tag-color-${color}`}
+                onClick={() => setNewTagColor(color)}
+                color={newTagColor === color ? 'primary' : 'secondary'}
+              >
+                {color}
+              </Button>
+            ))}
+          </Flex>
+          <Button
+            size="small"
+            margin="x-small 0 0 0"
+            data-testid="text-clips-create-tag"
+            onClick={() => createTagMutation.mutate()}
+            interaction={createTagMutation.isPending || !newTagName.trim() ? 'disabled' : 'enabled'}
+          >
+            {I18n.t('Create')}
+          </Button>
+        </View>
+      )}
 
       <View margin="small 0">
         <TextInput
@@ -355,8 +647,10 @@ export default function TextClipsTray() {
                 clip={clip}
                 editingId={editingId}
                 editDraft={editDraft}
+                allTags={clipTags}
                 onStartEdit={startEdit}
                 onEditDraftChange={setEditDraft}
+                onToggleEditTag={toggleEditTag}
                 onCancelEdit={() => {
                   setEditingId(null)
                   setEditDraft(null)

--- a/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+++ b/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
@@ -59,7 +59,10 @@ describe('sourceLinkLabel', () => {
 describe('TextClipsTray', () => {
   const oldCourseId = window.ENV.COURSE_ID
 
-  beforeAll(() => server.listen())
+  beforeAll(() => {
+    server.listen()
+    server.use(http.get('*/api/v1/users/self/clip_tags', () => HttpResponse.json([])))
+  })
   afterEach(() => {
     server.resetHandlers()
     cleanup()
@@ -69,7 +72,10 @@ describe('TextClipsTray', () => {
 
   it('shows empty state when there are no clips', async () => {
     window.ENV.COURSE_ID = '42'
-    server.use(http.get('*/api/v1/courses/42/text_clips', () => HttpResponse.json([])))
+    server.use(
+      http.get('*/api/v1/users/self/clip_tags', () => HttpResponse.json([])),
+      http.get('*/api/v1/courses/42/text_clips', () => HttpResponse.json([])),
+    )
     render(
       <MockedQueryProvider>
         <TextClipsTray />
@@ -91,6 +97,7 @@ describe('TextClipsTray', () => {
       },
     ]
     server.use(
+      http.get('*/api/v1/users/self/clip_tags', () => HttpResponse.json([])),
       http.get('*/api/v1/courses/7/text_clips', () => HttpResponse.json(clips)),
       http.delete('*/api/v1/courses/7/text_clips/1', () => {
         clips = []
@@ -263,6 +270,131 @@ describe('TextClipsTray', () => {
     await user.click(screen.getByTestId('text-clip-cancel-1'))
     expect(putCalled).toBe(false)
     expect(screen.getByText(/alpha/)).toBeInTheDocument()
+  })
+
+  it('renders tag chips under clip content', async () => {
+    window.ENV.COURSE_ID = '20'
+    server.use(
+      http.get('*/api/v1/users/self/clip_tags', () => HttpResponse.json([])),
+      http.get('*/api/v1/courses/20/text_clips', () =>
+        HttpResponse.json([
+          {
+            ...baseClip,
+            tags: [{id: 10, name: 'Exam', color: 'orange'}],
+          },
+        ]),
+      ),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId('text-clip-tag-1-10')).toHaveTextContent('Exam'))
+  })
+
+  it('filters clips when a tag chip is clicked', async () => {
+    window.ENV.COURSE_ID = '21'
+    const user = userEvent.setup()
+    const requests: string[] = []
+    server.use(
+      http.get('*/api/v1/users/self/clip_tags', () =>
+        HttpResponse.json([{id: 5, name: 'Exam', color: 'blue', workflow_state: 'active'}]),
+      ),
+      http.get('*/api/v1/courses/21/text_clips', ({request}) => {
+        requests.push(request.url)
+        const url = new URL(request.url)
+        if (url.searchParams.getAll('tag_ids[]').includes('5')) {
+          return HttpResponse.json([{...baseClip, id: 2, content: 'tagged only'}])
+        }
+        return HttpResponse.json([baseClip])
+      }),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId('text-clips-filter-tag-5')).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clips-filter-tag-5'))
+    await waitFor(() => expect(screen.getByText(/tagged only/)).toBeInTheDocument())
+    expect(requests.some(url => url.includes('tag_ids'))).toBe(true)
+    await user.click(screen.getByTestId('text-clips-clear-filters'))
+    await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
+  })
+
+  it('saves tag_ids from the editor via PUT', async () => {
+    window.ENV.COURSE_ID = '22'
+    const user = userEvent.setup()
+    let putBody: Record<string, unknown> | null = null
+    server.use(
+      http.get('*/api/v1/users/self/clip_tags', () =>
+        HttpResponse.json([
+          {
+            id: 7,
+            name: 'Exam',
+            color: 'green',
+            workflow_state: 'active',
+            created_at: '',
+            updated_at: '',
+          },
+        ]),
+      ),
+      http.get('*/api/v1/courses/22/text_clips', () => HttpResponse.json([baseClip])),
+      http.put('*/api/v1/courses/22/text_clips/1', async ({request}) => {
+        putBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json({
+          ...baseClip,
+          tag_ids: putBody?.tag_ids,
+          tags: [{id: 7, name: 'Exam', color: 'green'}],
+        })
+      }),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clip-edit-1'))
+    await waitFor(() => expect(screen.getByTestId('text-clip-edit-tag-1-7')).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clip-edit-tag-1-7'))
+    await user.click(screen.getByTestId('text-clip-save-1'))
+    await waitFor(() => expect(putBody?.tag_ids).toEqual([7]))
+  })
+
+  it('creates and deletes a tag in the manage panel', async () => {
+    window.ENV.COURSE_ID = '23'
+    const user = userEvent.setup()
+    let tags: Array<{id: number; name: string; color: string; workflow_state: string}> = []
+    server.use(
+      http.get('*/api/v1/users/self/clip_tags', () => HttpResponse.json(tags)),
+      http.get('*/api/v1/courses/23/text_clips', () => HttpResponse.json([])),
+      http.post('*/api/v1/users/self/clip_tags', async ({request}) => {
+        const body = (await request.json()) as {name: string; color: string}
+        const tag = {id: 99, name: body.name, color: body.color, workflow_state: 'active'}
+        tags = [tag]
+        return HttpResponse.json(tag, {status: 201})
+      }),
+      http.delete('*/api/v1/users/self/clip_tags/99', () => {
+        tags = []
+        return HttpResponse.json({})
+      }),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByText(/No clips yet/i)).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clips-manage-tags-toggle'))
+    await user.type(screen.getByTestId('text-clips-new-tag-name'), 'New label')
+    await user.click(screen.getByTestId('text-clips-create-tag'))
+    await waitFor(() => expect(screen.getByTestId('text-clips-filter-tag-99')).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clips-delete-tag-99'))
+    await waitFor(() =>
+      expect(screen.queryByTestId('text-clips-filter-tag-99')).not.toBeInTheDocument(),
+    )
   })
 
   it('shows undo after delete and restores the clip', async () => {

--- a/ui/features/text_clips/__tests__/api.test.ts
+++ b/ui/features/text_clips/__tests__/api.test.ts
@@ -17,7 +17,16 @@
  */
 
 import doFetchApiModule from '@canvas/do-fetch-api-effect'
-import {createTextClip, undeleteTextClip, updateTextClip} from '../api'
+import {
+  createClipTag,
+  createTextClip,
+  deleteClipTag,
+  fetchClipTags,
+  textClipsIndexPath,
+  undeleteTextClip,
+  updateClipTag,
+  updateTextClip,
+} from '../api'
 
 vi.mock('@canvas/do-fetch-api-effect', () => ({
   __esModule: true,
@@ -67,6 +76,60 @@ describe('text_clips api', () => {
     expect(doFetchApi).toHaveBeenCalledWith({
       path: '/api/v1/courses/42/text_clips/9/undestroy',
       method: 'POST',
+    })
+  })
+
+  it('textClipsIndexPath serializes tag_ids[]', () => {
+    const path = textClipsIndexPath('42', {tagIds: [1, 3]})
+    expect(path).toContain('tag_ids%5B%5D=1')
+    expect(path).toContain('tag_ids%5B%5D=3')
+  })
+
+  it('updateTextClip PUTs tag_ids', async () => {
+    await updateTextClip('42', 9, {tag_ids: [1, 2]})
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/courses/42/text_clips/9',
+      method: 'PUT',
+      body: {tag_ids: [1, 2]},
+    })
+  })
+
+  it('fetchClipTags GETs users/self/clip_tags', async () => {
+    doFetchApi.mockResolvedValueOnce({
+      json: [{id: 1, name: 'Exam', color: 'blue'}],
+      response: new Response(),
+      text: '',
+    })
+    await fetchClipTags()
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/users/self/clip_tags',
+      method: 'GET',
+    })
+  })
+
+  it('createClipTag POSTs name and color', async () => {
+    await createClipTag({name: 'Exam', color: 'green'})
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/users/self/clip_tags',
+      method: 'POST',
+      body: {name: 'Exam', color: 'green'},
+    })
+  })
+
+  it('updateClipTag PUTs partial body', async () => {
+    await updateClipTag(5, {name: 'Renamed'})
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/users/self/clip_tags/5',
+      method: 'PUT',
+      body: {name: 'Renamed'},
+    })
+  })
+
+  it('deleteClipTag DELETEs by id', async () => {
+    await deleteClipTag(5)
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/users/self/clip_tags/5',
+      method: 'DELETE',
     })
   })
 })

--- a/ui/features/text_clips/api.ts
+++ b/ui/features/text_clips/api.ts
@@ -17,18 +17,73 @@
  */
 
 import doFetchApi from '@canvas/do-fetch-api-effect'
-import type {TextClipCreate, TextClipRecord, TextClipUpdate, TextClipsPage} from './types'
+import type {
+  ClipTagColor,
+  ClipTagRecord,
+  TextClipCreate,
+  TextClipRecord,
+  TextClipUpdate,
+  TextClipsPage,
+} from './types'
 
 export function textClipsIndexPath(
   courseId: string | number,
-  opts?: {q?: string; perPage?: number},
+  opts?: {q?: string; perPage?: number; tagIds?: Array<number | string>},
 ): string {
   const params = new URLSearchParams()
   params.set('per_page', String(opts?.perPage ?? 20))
   if (opts?.q) {
     params.set('q', opts.q)
   }
+  for (const tagId of opts?.tagIds ?? []) {
+    params.append('tag_ids[]', String(tagId))
+  }
   return `/api/v1/courses/${courseId}/text_clips?${params.toString()}`
+}
+
+export async function fetchClipTags(): Promise<ClipTagRecord[]> {
+  const {json} = await doFetchApi<ClipTagRecord[]>({
+    path: '/api/v1/users/self/clip_tags',
+    method: 'GET',
+  })
+  return json ?? []
+}
+
+export async function createClipTag(body: {
+  name: string
+  color: ClipTagColor
+}): Promise<ClipTagRecord> {
+  const {json} = await doFetchApi<ClipTagRecord>({
+    path: '/api/v1/users/self/clip_tags',
+    method: 'POST',
+    body,
+  })
+  if (!json) {
+    throw new Error('createClipTag: empty response')
+  }
+  return json
+}
+
+export async function updateClipTag(
+  id: string | number,
+  body: Partial<{name: string; color: ClipTagColor}>,
+): Promise<ClipTagRecord> {
+  const {json} = await doFetchApi<ClipTagRecord>({
+    path: `/api/v1/users/self/clip_tags/${id}`,
+    method: 'PUT',
+    body,
+  })
+  if (!json) {
+    throw new Error('updateClipTag: empty response')
+  }
+  return json
+}
+
+export async function deleteClipTag(id: string | number): Promise<void> {
+  await doFetchApi({
+    path: `/api/v1/users/self/clip_tags/${id}`,
+    method: 'DELETE',
+  })
 }
 
 export async function fetchTextClipsPage(path: string): Promise<TextClipsPage> {

--- a/ui/features/text_clips/tagColors.ts
+++ b/ui/features/text_clips/tagColors.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type {ClipTagColor} from './types'
+
+export const CLIP_TAG_PALETTE: ClipTagColor[] = [
+  'blue',
+  'green',
+  'orange',
+  'purple',
+  'red',
+  'gray',
+  'yellow',
+  'pink',
+]
+
+export const CLIP_TAG_THEME: Record<
+  ClipTagColor,
+  {background: string; borderColor: string; color: string}
+> = {
+  blue: {background: '#E6F4FF', borderColor: '#0374B5', color: '#0374B5'},
+  green: {background: '#E8F8E8', borderColor: '#0B874B', color: '#0B874B'},
+  orange: {background: '#FFF4E6', borderColor: '#C87B00', color: '#C87B00'},
+  purple: {background: '#F3E8FF', borderColor: '#6B3FA0', color: '#6B3FA0'},
+  red: {background: '#FFE8E8', borderColor: '#D01A1A', color: '#D01A1A'},
+  gray: {background: '#F2F4F4', borderColor: '#6A7883', color: '#6A7883'},
+  yellow: {background: '#FFFBE6', borderColor: '#9A7500', color: '#9A7500'},
+  pink: {background: '#FFE6F4', borderColor: '#B5006A', color: '#B5006A'},
+}

--- a/ui/features/text_clips/types.ts
+++ b/ui/features/text_clips/types.ts
@@ -16,12 +16,38 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+export type ClipTagColor =
+  | 'blue'
+  | 'green'
+  | 'orange'
+  | 'purple'
+  | 'red'
+  | 'gray'
+  | 'yellow'
+  | 'pink'
+
+export type ClipTagRecord = {
+  id: number | string
+  name: string
+  color: ClipTagColor
+  workflow_state: string
+  created_at: string
+  updated_at: string
+}
+
+export type TextClipTagStub = {
+  id: number | string
+  name: string
+  color: ClipTagColor
+}
+
 export type TextClipRecord = {
   id: number | string
   content: string
   source_url?: string | null
   source_title?: string | null
   note?: string | null
+  tags?: TextClipTagStub[]
   user_id: number
   course_id: number | null
   workflow_state: string
@@ -38,6 +64,7 @@ export type TextClipCreate = {
 export type TextClipUpdate = {
   content?: string
   note?: string
+  tag_ids?: Array<number | string>
 }
 
 export type TextClipsPage = {


### PR DESCRIPTION
## Summary
- Add per-user `clip_tags` and `text_clip_taggings` tables with soft-delete and sharding.
- Expose `ClipTagsController` CRUD at `/api/v1/users/self/clip_tags` and extend `TextClipsController` with `tag_ids[]` filter on index and idempotent tag replacement on update.
- Update the Text Clips tray with tag filter chips, inline tag picker in the editor, and a manage-tags panel.

## Test plan
- [x] `bundle exec rails db:migrate RAILS_ENV=development`
- [x] `bin/rspec spec/models/clip_tag_spec.rb spec/models/text_clip_tagging_spec.rb spec/models/text_clip_spec.rb spec/controllers/clip_tags_controller_spec.rb spec/controllers/text_clips_controller_spec.rb`
- [x] `yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx`

Made with [Cursor](https://cursor.com)