### PR TITLE
[Text Clipper] Slice 6 — read-only share links

### DIFF
--- a/app/controllers/shared_text_clips_controller.rb
+++ b/app/controllers/shared_text_clips_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+class SharedTextClipsController < ApplicationController
+  include Api::V1::TextClip
+
+  skip_before_action :require_user, only: :show
+
+  def show
+    share = find_active_share_by_token(params[:token])
+    raise ActiveRecord::RecordNotFound unless share
+
+    @clip = on_clip_shard(share.text_clip) do
+      TextClip.preload(:course).find(share.text_clip_id)
+    end
+    respond_to do |format|
+      format.html { render :show, layout: false }
+      format.json { render json: shared_text_clip_public_json(@clip) }
+    end
+  rescue ActiveRecord::RecordNotFound
+    respond_to do |format|
+      format.html { render plain: I18n.t("Not found"), status: :not_found }
+      format.json do
+        render json: { errors: [{ message: "not found" }] }, status: :not_found
+      end
+    end
+  end
+
+  private
+
+  def find_active_share_by_token(token)
+    shards = [@domain_root_account.shard]
+    Shard.with_each_shard(shards) do
+      share = TextClipShare.active.preload(:text_clip).find_by(token:)
+      return share if share
+    end
+    nil
+  end
+
+  def on_clip_shard(clip, &)
+    if clip.course_id
+      Course.find(clip.course_id).shard.activate(&)
+    else
+      clip.user.shard.activate(&)
+    end
+  end
+end

--- a/app/controllers/text_clips_controller.rb
+++ b/app/controllers/text_clips_controller.rb
@@ -29,7 +29,9 @@ class TextClipsController < ApplicationController
   before_action :load_clip_context
   before_action :require_context_and_read_access, if: :course_scoped?
   before_action :require_course_context, if: :course_scoped?
-  before_action :check_limited_access_for_students, only: %i[index create update destroy undestroy], if: :course_scoped?
+  before_action :check_limited_access_for_students,
+                only: %i[index create update destroy undestroy share unshare],
+                if: :course_scoped?
 
   # @API List text clips
   #
@@ -52,7 +54,7 @@ class TextClipsController < ApplicationController
                           .active
                           .searchable(q)
                           .with_any_tag(tag_ids)
-                          .preload(:clip_tags, :course)
+                          .preload(:clip_tags, :course, :active_text_clip_share)
       if course_scoped?
         base.for_course(@context)
       else
@@ -60,7 +62,7 @@ class TextClipsController < ApplicationController
       end.order(created_at: :desc)
     end
     paginated = Api.paginate(clips, self, index_url)
-    render json: text_clips_json(paginated, @current_user, session)
+    render json: text_clips_json(paginated, @current_user, session, { host: request.host_with_port })
   end
 
   # @API Create a text clip
@@ -129,6 +131,39 @@ class TextClipsController < ApplicationController
     else
       render json: clip.errors, status: :bad_request
     end
+  end
+
+  # @API Create or return a read-only share link for a text clip
+  #
+  def share
+    clip = find_clip_for_current_user(active: true)
+    return unless clip.is_a?(TextClip)
+
+    share_record = on_clip_shard(clip) do
+      existing = clip.active_share
+      next existing if existing
+
+      share = clip.text_clip_shares.build(user: @current_user)
+      if share.save
+        share
+      else
+        render json: share.errors, status: :unprocessable_content
+        return
+      end
+    end
+    render json: text_clip_share_json(share_record, host: request.host_with_port), status: :ok
+  end
+
+  # @API Revoke the read-only share link for a text clip
+  #
+  def unshare
+    clip = find_clip_for_current_user(active: true)
+    return unless clip.is_a?(TextClip)
+
+    on_clip_shard(clip) do
+      clip.text_clip_shares.active.find_each(&:destroy)
+    end
+    render json: { revoked: true }, status: :ok
   end
 
   # @API Restore a soft-deleted text clip

--- a/app/models/text_clip.rb
+++ b/app/models/text_clip.rb
@@ -26,6 +26,12 @@ class TextClip < ApplicationRecord
   has_many :text_clip_taggings, dependent: :destroy
   has_many :active_text_clip_taggings, -> { active }, class_name: "TextClipTagging"
   has_many :clip_tags, -> { active }, through: :active_text_clip_taggings, source: :clip_tag
+  has_many :text_clip_shares, dependent: :destroy
+  has_one :active_text_clip_share, -> { active }, class_name: "TextClipShare"
+
+  def active_share
+    active_text_clip_share
+  end
 
   resolves_root_account through: lambda { |clip|
     clip.course&.root_account_id ||

--- a/app/models/text_clip_share.rb
+++ b/app/models/text_clip_share.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+class TextClipShare < ApplicationRecord
+  extend RootAccountResolver
+  include Canvas::SoftDeletable
+
+  belongs_to :text_clip
+  belongs_to :user
+
+  resolves_root_account through: :text_clip
+
+  validates :token, presence: true, uniqueness: true
+  validates :workflow_state, presence: true
+  validates :text_clip_id, uniqueness: { conditions: -> { active } }
+
+  before_validation :assign_token, on: :create
+
+  scope :for_user, ->(user) { where(user:) }
+
+  def assign_token
+    self.token ||= CanvasSlug.generate_securish_uuid
+  end
+end

--- a/app/views/shared_text_clips/show.html.erb
+++ b/app/views/shared_text_clips/show.html.erb
@@ -1,0 +1,31 @@
+<%# Copyright (C) 2026 - present Instructure, Inc. %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title><%= t("Shared text clip", :scope => :text_clips) %></title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; max-width: 48rem; line-height: 1.5; }
+    .meta { color: #555; font-size: 0.875rem; margin-top: 1rem; }
+    .content { white-space: pre-wrap; margin-top: 1rem; }
+    a { color: #0374b5; }
+  </style>
+</head>
+<body>
+  <h1><%= t("Shared text clip", :scope => :text_clips) %></h1>
+  <div class="content"><%= h(@clip.content) %></div>
+  <% if @clip.source_url.present? %>
+    <p class="meta">
+      <%= t("Source", :scope => :text_clips) %>:
+      <a href="<%= h(@clip.source_url) %>" rel="noopener noreferrer">
+        <%= h(@clip.source_title.presence || @clip.source_url) %>
+      </a>
+    </p>
+  <% end %>
+  <% if @clip.course %>
+    <p class="meta"><%= t("Course", :scope => :text_clips) %>: <%= h(@clip.course.name) %></p>
+  <% end %>
+  <p class="meta"><%= t("Saved", :scope => :text_clips) %>: <%= l(@clip.created_at, format: :long) %></p>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -675,6 +675,8 @@ CanvasRails::Application.routes.draw do
     concerns :files
   end
 
+  get "text_clips/shared/:token" => "shared_text_clips#show", :as => :shared_text_clip
+
   resources :eportfolios, except: :index do
     post :reorder_categories
     post ":eportfolio_category_id/reorder_entries" => "eportfolios#reorder_entries", :as => :reorder_entries
@@ -2891,6 +2893,8 @@ CanvasRails::Application.routes.draw do
       put "courses/:course_id/text_clips/:id", action: :update
       delete "courses/:course_id/text_clips/:id", action: :destroy
       post "courses/:course_id/text_clips/:id/undestroy", action: :undestroy, as: :undestroy_course_text_clip
+      post "courses/:course_id/text_clips/:id/share", action: :share, as: :share_course_text_clip
+      delete "courses/:course_id/text_clips/:id/share", action: :unshare, as: :unshare_course_text_clip
     end
 
     scope(controller: :text_clips) do
@@ -2899,6 +2903,8 @@ CanvasRails::Application.routes.draw do
       put "users/:user_id/text_clips/:id", action: :update
       delete "users/:user_id/text_clips/:id", action: :destroy
       post "users/:user_id/text_clips/:id/undestroy", action: :undestroy, as: :undestroy_user_text_clip
+      post "users/:user_id/text_clips/:id/share", action: :share, as: :share_user_text_clip
+      delete "users/:user_id/text_clips/:id/share", action: :unshare, as: :unshare_user_text_clip
     end
 
     scope(controller: :clip_tags) do

--- a/db/migrate/20260602120000_create_text_clip_shares.rb
+++ b/db/migrate/20260602120000_create_text_clip_shares.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+class CreateTextClipShares < ActiveRecord::Migration[8.0]
+  tag :predeploy
+
+  def change
+    create_table :text_clip_shares do |t|
+      t.references :text_clip, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :token, null: false, limit: 255
+      t.string :workflow_state, null: false, default: "active", limit: 255
+      t.references :root_account, null: false, foreign_key: { to_table: :accounts }, index: false
+      t.timestamps
+
+      t.check_constraint "workflow_state IN ('active', 'deleted')", name: "chk_text_clip_shares_workflow_state_enum"
+      t.replica_identity_index
+      t.index :token, unique: true
+      t.index :text_clip_id,
+              unique: true,
+              where: "workflow_state = 'active'",
+              name: "index_text_clip_shares_unique_active_per_clip"
+    end
+  end
+end

--- a/lib/api/v1/text_clip.rb
+++ b/lib/api/v1/text_clip.rb
@@ -20,6 +20,7 @@
 
 module Api::V1::TextClip
   include Api::V1::Json
+  include Api::V1::TextClipShare
 
   API_JSON_OPTS = {
     only: %w[id content source_url source_title note user_id course_id workflow_state created_at updated_at]
@@ -29,7 +30,19 @@ module Api::V1::TextClip
     json = api_json(clip, user, session, opts.merge(API_JSON_OPTS))
     json["tags"] = clip.clip_tags.map { |t| { "id" => t.id, "name" => t.name, "color" => t.color } }
     json["course"] = clip.course && { "id" => clip.course.id, "name" => clip.course.name }
+    share = clip.active_share
+    json["share"] = share ? text_clip_share_json(share, host: opts[:host]) : nil
     json
+  end
+
+  def shared_text_clip_public_json(clip)
+    {
+      "content" => clip.content,
+      "source_url" => clip.source_url,
+      "source_title" => clip.source_title,
+      "course" => clip.course && { "name" => clip.course.name },
+      "created_at" => clip.created_at
+    }
   end
 
   def text_clips_json(clips, user, session, opts = {})

--- a/lib/api/v1/text_clip_share.rb
+++ b/lib/api/v1/text_clip_share.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module Api::V1::TextClipShare
+  def text_clip_share_json(share, host: nil)
+    {
+      "token" => share.token,
+      "url" => shared_text_clip_url(share.token, host: host || HostUrl.default_host)
+    }
+  end
+end

--- a/spec/controllers/shared_text_clips_controller_spec.rb
+++ b/spec/controllers/shared_text_clips_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe SharedTextClipsController do
+  before :once do
+    course_with_teacher(active_all: true)
+    @course.shard.activate do
+      @clip = TextClip.create!(
+        user_id: @teacher.id,
+        course_id: @course.id,
+        content: "Public clip body",
+        source_url: "https://example.com/page",
+        source_title: "Week 1",
+        note: "Private note",
+        root_account_id: @course.root_account_id
+      )
+      @share = TextClipShare.create!(text_clip: @clip, user: @teacher)
+    end
+  end
+
+  describe "GET #show" do
+    it "returns public clip fields for an anonymous viewer" do
+      get :show, params: { token: @share.token }, format: :json
+      expect(response).to be_successful
+      body = json_parse(response.body)
+      expect(body["content"]).to eql "Public clip body"
+      expect(body["source_url"]).to eql "https://example.com/page"
+      expect(body["source_title"]).to eql "Week 1"
+      expect(body["course"]).to eq({ "name" => @course.name })
+      expect(body).not_to have_key("note")
+      expect(body).not_to have_key("tags")
+      expect(body).not_to have_key("user_id")
+    end
+
+    it "returns 404 for an invalid token" do
+      get :show, params: { token: "invalid-token" }, format: :json
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 after the share is revoked" do
+      @share.destroy
+      get :show, params: { token: @share.token }, format: :json
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/controllers/text_clips_controller_spec.rb
+++ b/spec/controllers/text_clips_controller_spec.rb
@@ -482,4 +482,53 @@ describe TextClipsController do
       end
     end
   end
+
+  context "share and unshare" do
+    before do
+      user_session(@teacher)
+      @teacher_clip = create_clip_for(@teacher, @course, "Share target")
+      @student_clip = create_clip_for(@student, @course, "Student clip")
+    end
+
+    describe "POST #share" do
+      it "creates a share link for the owner's clip" do
+        post :share, format: :json, params: { course_id: @course.id, id: @teacher_clip.id }
+        expect(response).to be_successful
+        body = json_parse(response.body)
+        expect(body["token"]).to be_present
+        expect(body["url"]).to include(body["token"])
+        share = @course.shard.activate { @teacher_clip.reload.active_share }
+        expect(share).to be_present
+      end
+
+      it "returns the same token when share is requested again" do
+        post :share, format: :json, params: { course_id: @course.id, id: @teacher_clip.id }
+        first_token = json_parse(response.body)["token"]
+        post :share, format: :json, params: { course_id: @course.id, id: @teacher_clip.id }
+        expect(json_parse(response.body)["token"]).to eql first_token
+      end
+
+      it "returns not found for another user's clip" do
+        post :share, format: :json, params: { course_id: @course.id, id: @student_clip.id }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "DELETE #unshare" do
+      it "revokes the active share link" do
+        post :share, format: :json, params: { course_id: @course.id, id: @teacher_clip.id }
+        delete :unshare, format: :json, params: { course_id: @course.id, id: @teacher_clip.id }
+        expect(response).to be_successful
+        expect(@course.shard.activate { @teacher_clip.reload.active_share }).to be_nil
+      end
+    end
+
+    describe "POST #share on global routes" do
+      it "creates a share link via users/self" do
+        post :share, format: :json, params: { user_id: "self", id: @teacher_clip.id }
+        expect(response).to be_successful
+        expect(json_parse(response.body)["token"]).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/text_clip_share_spec.rb
+++ b/spec/models/text_clip_share_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe TextClipShare do
+  before :once do
+    course_factory
+    student_in_course
+    @clip = TextClip.create!(
+      user_id: @student.id,
+      course_id: @course.id,
+      content: "Shareable clip",
+      root_account_id: @course.root_account_id
+    )
+  end
+
+  it "assigns a unique token on create" do
+    share = TextClipShare.create!(text_clip: @clip, user: @student)
+    expect(share.token).to be_present
+    expect(share.token.length).to be >= 20
+    other = TextClipShare.create!(
+      text_clip: TextClip.create!(
+        user_id: @student.id,
+        course_id: @course.id,
+        content: "Other clip",
+        root_account_id: @course.root_account_id
+      ),
+      user: @student
+    )
+    expect(other.token).not_to eql share.token
+  end
+
+  it "resolves root_account_id through the text clip" do
+    share = TextClipShare.create!(text_clip: @clip, user: @student)
+    expect(share.root_account_id).to eq @course.root_account_id
+  end
+
+  it "soft-deletes without removing the record" do
+    share = TextClipShare.create!(text_clip: @clip, user: @student)
+    share.destroy
+    share.reload
+    expect(share.workflow_state).to eql "deleted"
+    expect(TextClipShare.find(share.id)).to eql share
+  end
+
+  it "allows only one active share per clip" do
+    TextClipShare.create!(text_clip: @clip, user: @student)
+    duplicate = TextClipShare.new(text_clip: @clip, user: @student)
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:text_clip_id]).to be_present
+  end
+end

--- a/ui/features/navigation_header/react/trays/TextClipsTray.tsx
+++ b/ui/features/navigation_header/react/trays/TextClipsTray.tsx
@@ -21,7 +21,13 @@ import {Alert} from '@instructure/ui-alerts'
 import {Button, IconButton} from '@instructure/ui-buttons'
 import {Flex} from '@instructure/ui-flex'
 import {Heading} from '@instructure/ui-heading'
-import {IconEditLine, IconExternalLinkLine, IconTrashLine} from '@instructure/ui-icons'
+import {
+  IconCopyLine,
+  IconEditLine,
+  IconExternalLinkLine,
+  IconLinkLine,
+  IconTrashLine,
+} from '@instructure/ui-icons'
 import {Link} from '@instructure/ui-link'
 import {List} from '@instructure/ui-list'
 import {showFlashAlert} from '@instructure/platform-alerts'
@@ -41,9 +47,13 @@ import {
   fetchClipTags,
   fetchTextClipsPage,
   globalTextClipsIndexPath,
+  shareGlobalTextClip,
+  shareTextClip,
   textClipsIndexPath,
   undeleteGlobalTextClip,
   undeleteTextClip,
+  unshareGlobalTextClip,
+  unshareTextClip,
   updateClipTag,
   updateGlobalTextClip,
   updateTextClip,
@@ -123,8 +133,14 @@ type TextClipListItemProps = {
   onSaveEdit: (id: number | string, body: TextClipUpdate) => void
   onDelete: (clip: TextClipRecord) => void
   onToggleEditTag: (tagId: number | string) => void
+  sharePanelOpen: boolean
+  onToggleSharePanel: () => void
+  onCreateShare: () => void
+  onRevokeShare: () => void
+  onCopyShareLink: (url: string) => void
   isSaving: boolean
   isDeleting: boolean
+  isSharing: boolean
 }
 
 function TextClipListItem({
@@ -139,8 +155,14 @@ function TextClipListItem({
   onSaveEdit,
   onDelete,
   onToggleEditTag,
+  sharePanelOpen,
+  onToggleSharePanel,
+  onCreateShare,
+  onRevokeShare,
+  onCopyShareLink,
   isSaving,
   isDeleting,
+  isSharing,
 }: TextClipListItemProps) {
   const isEditing = editingId === clip.id
 
@@ -241,6 +263,15 @@ function TextClipListItem({
                 {clip.course.name}
               </Text>
             )}
+            {clip.share && (
+              <View margin="xx-small 0 0 0">
+                <Tag
+                  text={I18n.t('Shared')}
+                  margin="0"
+                  data-testid={`text-clip-shared-badge-${clip.id}`}
+                />
+              </View>
+            )}
             <View margin="xx-small 0 0 0">
               {clip.source_url && (
                 <Link
@@ -255,6 +286,15 @@ function TextClipListItem({
                   <IconExternalLinkLine size="x-small" style={{paddingLeft: '0.3em'}} />
                 </Link>
               )}
+              <IconButton
+                size="small"
+                margin="0 x-small 0 0"
+                screenReaderLabel={I18n.t('Share clip')}
+                renderIcon={IconLinkLine}
+                data-testid={`text-clip-share-${clip.id}`}
+                onClick={onToggleSharePanel}
+                interaction={isDeleting || isSharing ? 'disabled' : 'enabled'}
+              />
               <IconButton
                 size="small"
                 margin="0 x-small 0 0"
@@ -273,6 +313,54 @@ function TextClipListItem({
                 interaction={isDeleting ? 'disabled' : 'enabled'}
               />
             </View>
+            {sharePanelOpen && (
+              <View
+                margin="x-small 0 0 0"
+                padding="small"
+                borderWidth="small"
+                data-testid={`text-clip-share-panel-${clip.id}`}
+              >
+                {clip.share ? (
+                  <>
+                    <TextInput
+                      renderLabel={I18n.t('Share link')}
+                      value={clip.share.url}
+                      readOnly={true}
+                      data-testid={`text-clip-share-url-${clip.id}`}
+                    />
+                    <Flex margin="x-small 0 0 0">
+                      <Button
+                        size="small"
+                        margin="0 x-small 0 0"
+                        renderIcon={<IconCopyLine />}
+                        data-testid={`text-clip-copy-link-${clip.id}`}
+                        onClick={() => onCopyShareLink(clip.share!.url)}
+                      >
+                        {I18n.t('Copy link')}
+                      </Button>
+                      <Button
+                        size="small"
+                        color="danger"
+                        data-testid={`text-clip-stop-sharing-${clip.id}`}
+                        onClick={onRevokeShare}
+                        interaction={isSharing ? 'disabled' : 'enabled'}
+                      >
+                        {I18n.t('Stop sharing')}
+                      </Button>
+                    </Flex>
+                  </>
+                ) : (
+                  <Button
+                    size="small"
+                    data-testid={`text-clip-create-link-${clip.id}`}
+                    onClick={onCreateShare}
+                    interaction={isSharing ? 'disabled' : 'enabled'}
+                  >
+                    {I18n.t('Create link')}
+                  </Button>
+                )}
+              </View>
+            )}
           </>
         )}
       </View>
@@ -296,6 +384,7 @@ export default function TextClipsTray() {
   const [pendingUndo, setPendingUndo] = useState<PendingUndo | null>(null)
   const [renamingTagId, setRenamingTagId] = useState<number | string | null>(null)
   const [renameDraft, setRenameDraft] = useState('')
+  const [sharePanelClipId, setSharePanelClipId] = useState<number | string | null>(null)
 
   useEffect(() => {
     const handle = window.setTimeout(() => {
@@ -498,10 +587,40 @@ export default function TextClipsTray() {
       })
       setEditingId(null)
       setEditDraft(null)
+      setSharePanelClipId(null)
       invalidateClips()
       showFlashAlert({message: I18n.t('Clip deleted'), type: 'success'})
     },
   })
+
+  const shareMutation = useMutation({
+    mutationFn: (id: number | string) =>
+      mode === 'course' ? shareTextClip(courseId as string | number, id) : shareGlobalTextClip(id),
+    onSuccess: () => {
+      invalidateClips()
+      showFlashAlert({message: I18n.t('Share link created'), type: 'success'})
+    },
+  })
+
+  const unshareMutation = useMutation({
+    mutationFn: (id: number | string) =>
+      mode === 'course'
+        ? unshareTextClip(courseId as string | number, id)
+        : unshareGlobalTextClip(id),
+    onSuccess: () => {
+      invalidateClips()
+      showFlashAlert({message: I18n.t('Sharing stopped'), type: 'success'})
+    },
+  })
+
+  const copyShareLink = useCallback(async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url)
+      showFlashAlert({message: I18n.t('Link copied'), type: 'success'})
+    } catch (_e) {
+      showFlashAlert({message: I18n.t('Could not copy link'), type: 'error'})
+    }
+  }, [])
 
   const startEdit = (clip: TextClipRecord) => {
     setEditingId(clip.id)
@@ -765,8 +884,16 @@ export default function TextClipsTray() {
                 }}
                 onSaveEdit={(id, body) => updateMutation.mutate({id, body})}
                 onDelete={clipToDelete => deleteMutation.mutate(clipToDelete.id)}
+                sharePanelOpen={sharePanelClipId === clip.id}
+                onToggleSharePanel={() =>
+                  setSharePanelClipId(prev => (prev === clip.id ? null : clip.id))
+                }
+                onCreateShare={() => shareMutation.mutate(clip.id)}
+                onRevokeShare={() => unshareMutation.mutate(clip.id)}
+                onCopyShareLink={copyShareLink}
                 isSaving={updateMutation.isPending}
                 isDeleting={deleteMutation.isPending}
+                isSharing={shareMutation.isPending || unshareMutation.isPending}
               />
             ))}
           </List>

--- a/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+++ b/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
@@ -110,7 +110,9 @@ describe('TextClipsTray', () => {
       </MockedQueryProvider>,
     )
     await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
-    expect(screen.getByTestId('text-clip-source-1')).toHaveTextContent('Week 1 Page')
+    await waitFor(() =>
+      expect(screen.getByTestId('text-clip-source-1')).toHaveTextContent('Week 1 Page'),
+    )
     await user.click(screen.getByTestId('text-clip-delete-1'))
     await waitFor(() => expect(screen.getByText(/No clips yet/i)).toBeInTheDocument())
   })
@@ -503,5 +505,77 @@ describe('TextClipsTray', () => {
     await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
     expect(screen.queryByTestId('text-clips-course-filter')).not.toBeInTheDocument()
     expect(screen.queryByTestId('text-clip-course-1')).not.toBeInTheDocument()
+  })
+
+  it('creates a share link and shows copy controls', async () => {
+    window.ENV.COURSE_ID = '30'
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const clipboardStub = vi.spyOn(navigator.clipboard, 'writeText').mockImplementation(writeText)
+    let clips = [{...baseClip, share: null as {token: string; url: string} | null}]
+    server.use(
+      http.get('*/api/v1/users/self/clip_tags', () => HttpResponse.json([])),
+      http.get('*/api/v1/courses/30/text_clips', () => HttpResponse.json(clips)),
+      http.post('*/api/v1/courses/30/text_clips/1/share', () => {
+        clips = [
+          {
+            ...baseClip,
+            share: {
+              token: 'secret-token',
+              url: 'https://example.com/text_clips/shared/secret-token',
+            },
+          },
+        ]
+        return HttpResponse.json(clips[0].share, {status: 200})
+      }),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clip-share-1'))
+    await user.click(screen.getByTestId('text-clip-create-link-1'))
+    await waitFor(() =>
+      expect(screen.getByTestId('text-clip-share-url-1')).toHaveValue(
+        'https://example.com/text_clips/shared/secret-token',
+      ),
+    )
+    await user.click(screen.getByTestId('text-clip-copy-link-1'))
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith('https://example.com/text_clips/shared/secret-token'),
+    )
+    clipboardStub.mockRestore()
+  })
+
+  it('stops sharing and hides the shared badge', async () => {
+    window.ENV.COURSE_ID = '31'
+    const user = userEvent.setup()
+    let clips: TextClipRecord[] = [
+      {
+        ...baseClip,
+        share: {token: 't1', url: 'https://example.com/text_clips/shared/t1'},
+      },
+    ]
+    server.use(
+      http.get('*/api/v1/users/self/clip_tags', () => HttpResponse.json([])),
+      http.get('*/api/v1/courses/31/text_clips', () => HttpResponse.json(clips)),
+      http.delete('*/api/v1/courses/31/text_clips/1/share', () => {
+        clips = [{...baseClip, share: null}]
+        return HttpResponse.json({revoked: true})
+      }),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId('text-clip-shared-badge-1')).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clip-share-1'))
+    await user.click(screen.getByTestId('text-clip-stop-sharing-1'))
+    await waitFor(() =>
+      expect(screen.queryByTestId('text-clip-shared-badge-1')).not.toBeInTheDocument(),
+    )
   })
 })

--- a/ui/features/text_clips/__tests__/api.test.ts
+++ b/ui/features/text_clips/__tests__/api.test.ts
@@ -24,7 +24,11 @@ import {
   deleteClipTag,
   fetchClipTags,
   globalTextClipsIndexPath,
+  shareGlobalTextClip,
+  shareTextClip,
   textClipsIndexPath,
+  unshareGlobalTextClip,
+  unshareTextClip,
   undeleteTextClip,
   updateClipTag,
   updateTextClip,
@@ -98,6 +102,48 @@ describe('text_clips api', () => {
     expect(path).toContain('tag_ids%5B%5D=1')
     expect(path).toContain('course_ids%5B%5D=7')
     expect(path).toContain('course_ids%5B%5D=9')
+  })
+
+  it('shareTextClip POSTs to course share endpoint', async () => {
+    doFetchApi.mockResolvedValueOnce({
+      json: {token: 'abc', url: 'https://example.com/text_clips/shared/abc'},
+      response: new Response(),
+      text: '',
+    })
+    await shareTextClip('42', 9)
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/courses/42/text_clips/9/share',
+      method: 'POST',
+    })
+  })
+
+  it('unshareTextClip DELETEs course share endpoint', async () => {
+    await unshareTextClip('42', 9)
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/courses/42/text_clips/9/share',
+      method: 'DELETE',
+    })
+  })
+
+  it('shareGlobalTextClip POSTs to users/self share endpoint', async () => {
+    doFetchApi.mockResolvedValueOnce({
+      json: {token: 'xyz', url: 'https://example.com/text_clips/shared/xyz'},
+      response: new Response(),
+      text: '',
+    })
+    await shareGlobalTextClip(3)
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/users/self/text_clips/3/share',
+      method: 'POST',
+    })
+  })
+
+  it('unshareGlobalTextClip DELETEs users/self share endpoint', async () => {
+    await unshareGlobalTextClip(3)
+    expect(doFetchApi).toHaveBeenCalledWith({
+      path: '/api/v1/users/self/text_clips/3/share',
+      method: 'DELETE',
+    })
   })
 
   it('createGlobalTextClip POSTs to users/self/text_clips', async () => {

--- a/ui/features/text_clips/api.ts
+++ b/ui/features/text_clips/api.ts
@@ -22,6 +22,7 @@ import type {
   ClipTagRecord,
   TextClipCreate,
   TextClipRecord,
+  TextClipShareRecord,
   TextClipUpdate,
   TextClipsPage,
 } from './types'
@@ -217,4 +218,46 @@ export async function undeleteGlobalTextClip(id: string | number): Promise<TextC
     throw new Error('undeleteGlobalTextClip: empty response')
   }
   return json
+}
+
+export async function shareTextClip(
+  courseId: string | number,
+  id: string | number,
+): Promise<TextClipShareRecord> {
+  const {json} = await doFetchApi<TextClipShareRecord>({
+    path: `/api/v1/courses/${courseId}/text_clips/${id}/share`,
+    method: 'POST',
+  })
+  if (!json) {
+    throw new Error('shareTextClip: empty response')
+  }
+  return json
+}
+
+export async function unshareTextClip(
+  courseId: string | number,
+  id: string | number,
+): Promise<void> {
+  await doFetchApi({
+    path: `/api/v1/courses/${courseId}/text_clips/${id}/share`,
+    method: 'DELETE',
+  })
+}
+
+export async function shareGlobalTextClip(id: string | number): Promise<TextClipShareRecord> {
+  const {json} = await doFetchApi<TextClipShareRecord>({
+    path: `/api/v1/users/self/text_clips/${id}/share`,
+    method: 'POST',
+  })
+  if (!json) {
+    throw new Error('shareGlobalTextClip: empty response')
+  }
+  return json
+}
+
+export async function unshareGlobalTextClip(id: string | number): Promise<void> {
+  await doFetchApi({
+    path: `/api/v1/users/self/text_clips/${id}/share`,
+    method: 'DELETE',
+  })
 }

--- a/ui/features/text_clips/types.ts
+++ b/ui/features/text_clips/types.ts
@@ -41,6 +41,11 @@ export type TextClipTagStub = {
   color: ClipTagColor
 }
 
+export type TextClipShareRecord = {
+  token: string
+  url: string
+}
+
 export type TextClipRecord = {
   id: number | string
   content: string
@@ -48,6 +53,7 @@ export type TextClipRecord = {
   source_title?: string | null
   note?: string | null
   tags?: TextClipTagStub[]
+  share?: TextClipShareRecord | null
   course?: {id: number | string; name: string} | null
   user_id: number
   course_id: number | null


### PR DESCRIPTION
## Summary

- Adds `text_clip_shares` table and model (soft-deletable, one active link per clip)
- Owner `POST/DELETE .../text_clips/:id/share` on course and global routes
- Anonymous `GET /text_clips/shared/:token` (HTML + JSON) without note/tags/user
- Tray share UI: create link, copy, stop sharing, shared badge (course + global)

Refs #5
Refs #7
Refs #10
Refs #11

## Test plan

- [x] `docker compose run --rm web bin/rspec spec/models/text_clip_share_spec.rb spec/controllers/text_clips_controller_spec.rb spec/controllers/shared_text_clips_controller_spec.rb` → 44 examples, 0 failures
- [x] `yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx` → 39 tests, 0 failures
- [x] `yarn check:ts` → pass
- [x] `bin/rubocop` on touched Ruby → no offenses
- [ ] Manual: create link in tray, open logged out, revoke → 404

Made with [Cursor](https://cursor.com)