### PR TITLE
Add Text clips nav entry and slice 5+ progress doc

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -1,5 +1,7 @@
 # Implementation evidence — Lab 3.2 (Canvas Text Clipper)
 
+**Narrative progress (Slice 5 onward, dev setup, manual QA):** [`progress-slice-5-onward.md`](progress-slice-5-onward.md) — use that file as the main Cursor reference on another machine.
+
 ## PR links
 
 | PR | Description |
@@ -105,3 +107,50 @@ Exposes nullable `course_id` from Story 1 as a **personal cross-course collectio
 ### Trace
 
 First outward-facing clip capability per [`.cursor/plans/text_clipper_slice_6_31ac498c.plan.md`](../../../.cursor/plans/text_clipper_slice_6_31ac498c.plan.md); Eportfolio-style secret token, revocable per clip.
+
+### Manual verification (Slice 6)
+
+| Check | Result | When |
+|-------|--------|------|
+| Create share link from tray; copy URL | Pass | 2026-06-02 |
+| Incognito / logged-out shared page (public fields only) | Pass | 2026-06-02 |
+| Stop sharing → reload shared URL → 404 | Pass | 2026-06-02 |
+
+Details and step-by-step checklist: [`progress-slice-5-onward.md`](progress-slice-5-onward.md) § Slice 6 manual verification.
+
+## Post-merge dev session (2026-06-02) — nav + Docker
+
+Not merged to `master` as of last evidence update; tracked for the next PR.
+
+### Problem
+
+`instui_nav` enabled in DB but browser often showed **classic** left nav (Account, Dashboard, Courses, …) with **no** Text clips entry. InstUI `SideNav` only mounts when `ENV.FEATURES.instui_nav` is true **and** `navigation_header` webpack bundles load.
+
+### Root causes found
+
+1. **`webpack` container exited** after initial compile when `docker compose up` ran in the foreground (terminal killed → services stopped).
+2. **Stale Redis** `rails80:js_env_account_features/*` cached `instui_nav: false` in page ENV.
+3. **Classic ERB nav** had no Text clips row; tray wiring lived only in InstUI `SideNav` / `OldSideNav` click handlers.
+
+### Fixes applied locally
+
+| File | Purpose |
+|------|---------|
+| `app/views/shared/_new_nav_header.html.erb` | Server-rendered “Text clips” above Help |
+| `ui/features/navigation_header/react/OldSideNav.tsx` | Open `TextClipsTray` from `#global_nav_text_clips_link` |
+| `ui/features/navigation_header/index.tsx` | Mount InstUI `SideNav` into `#header` when `instui_nav` |
+| `ui/features/navigation_header/react/utils.ts` | Tray label for `text_clips` |
+| `app/stylesheets/base/_SideNav.scss` | `#text-clips-tray` styles |
+| `config/feature_flags/app_fundamentals_release_flags.yml` | `instui_nav` allowed in development |
+
+### Ops that restored a working dev UI
+
+```bash
+docker compose up -d
+docker compose exec -T redis redis-cli --scan --pattern 'rails80:js_env_account_features*' | xargs -r docker compose exec -T redis redis-cli DEL
+docker compose up -d webpack
+docker compose restart web
+# browser: hard refresh http://localhost:3000
+```
+
+**Verified:** Text clips visible in left nav; Slice 6 share manual checklist passed. Full write-up: [`progress-slice-5-onward.md`](progress-slice-5-onward.md).

--- a/agents/tasks/feature-1/implementation-research.md
+++ b/agents/tasks/feature-1/implementation-research.md
@@ -1,5 +1,7 @@
 # Implementation Research — Canvas Text Clipper
 
+**Progress from Slice 5 onward (merged PRs, manual QA, dev environment):** [`progress-slice-5-onward.md`](progress-slice-5-onward.md).
+
 ## Feature Summary
 
 The Text Clipper lets students highlight and save text from any Canvas page into a persistent tray panel. Clips are scoped to the current user and course, with the data model designed to support global (course-agnostic) clips in the future. See `agents/tasks/feature-1/feature-1.md` for the full problem statement and pitch.

--- a/agents/tasks/feature-1/progress-slice-5-onward.md
+++ b/agents/tasks/feature-1/progress-slice-5-onward.md
@@ -1,0 +1,262 @@
+# Text Clipper — progress from Slice 5 onward
+
+**Primary reference for continuing work on another machine.** Open this file in Cursor after cloning/pulling `THAT-ON3-GUY/canvas-lms` on `master`.
+
+Related evidence (automated tests / PR table):
+
+- [`implementation-evidence.md`](implementation-evidence.md) — merge commits, board traceability, scope per PR
+- [`qa-lab-evidence.md`](qa-lab-evidence.md) — RSpec/Jest commands and outcomes
+- Plans: [`.cursor/plans/text_clipper_slice_5.plan.md`](../../../.cursor/plans/text_clipper_slice_5.plan.md) (global clips), slice 6 plan referenced in evidence (share links)
+
+---
+
+## Timeline (merged to `master`)
+
+| When (UTC) | Slice | PR | Merge commit | Summary |
+|------------|-------|-----|--------------|---------|
+| 2026-06-02 | **5 — Global clips** | [#21](https://github.com/THAT-ON3-GUY/canvas-lms/pull/21) | `97c58ae4544` | Cross-course tray, `/users/self/text_clips`, off-course selection save |
+| 2026-06-02 | **6 — Share links** | [#22](https://github.com/THAT-ON3-GUY/canvas-lms/pull/22) | `b9dfadfcbad` | Revocable public URLs, tray share UI |
+| 2026-06-02 | Evidence on `master` | — | `0c61ad1ee34`, `6e270ef18c7` | Recorded slice 5/6 merges in evidence docs |
+
+**Prerequisites on `master` before Slice 5:** Slices 1–4 (migration, model, controller, routes, tray UI, edit/notes/undo, tags/filtering) via PRs #17–#20. See [`implementation-evidence.md`](implementation-evidence.md) for earlier slices.
+
+---
+
+## Slice 5 — Global clips view (PR #21)
+
+### Problem solved
+
+Clips were course-only in the UI: SideNav bookmark only on course pages, tray scoped to one course. Slice 5 uses nullable `course_id` (from Story 1) for a **personal cross-course collection** visible from anywhere.
+
+### Backend
+
+| Area | Change |
+|------|--------|
+| Routes | `GET/POST/PUT/DELETE` + `undestroy` under `/api/v1/users/:user_id/text_clips` |
+| Controller | `TextClipsController` supports course and global contexts; `course_ids[]` on global index |
+| Model | `scope :for_courses`; `resolves_root_account` falls back to user when `course_id` is nil |
+| Serializer | `course` stub `{id, name}` or null on each clip JSON |
+
+### Frontend
+
+| Area | Change |
+|------|--------|
+| Layout | `js_bundle(:text_clips)` for any logged-in user (not only in a course) |
+| SideNav | `IconBookmarkLine` “Text clips” always in InstUI `SideNav` (not gated on course) |
+| Tray | `mode`: `course` vs `global`; global uses `/users/self/text_clips`; course chip filter; per-row course label |
+| Selection | `TextClipsSelectionRoot` saves via global POST when `ENV.COURSE_ID` absent (`course_id: null`) |
+| API | `globalTextClipsIndexPath`, `createGlobalTextClip`, etc. in `ui/features/text_clips/api.ts` |
+
+### Issues referenced
+
+#5 (tray), #7 (API helpers), #8 (selection), #9 (SideNav), #16 (bundle wiring), #10 (partial RSpec).
+
+### Automated QA (pre-merge)
+
+| Command | Result |
+|---------|--------|
+| `docker compose run --rm web bin/rspec spec/models/text_clip_spec.rb spec/controllers/text_clips_controller_spec.rb` | 55 examples, 0 failures |
+| `yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx` | 33 tests, 0 failures |
+| `yarn check:ts` | pass |
+| `bin/rubocop` (touched Ruby) | no offenses |
+
+### Manual verification (Slice 5)
+
+From [slice 5 plan § Manual verification](../../../.cursor/plans/text_clipper_slice_5.plan.md):
+
+1. Log in → open **Dashboard** (not in a course) → confirm **Text clips** in nav → open tray → see clips from multiple courses.
+2. Use course filter chips → list narrows.
+3. On a course page, tray still shows that course’s clips (course mode).
+4. Select text on Dashboard → save to clips → clip appears with no course (or global list).
+5. Navigate between pages with tray open → tray stays open (`text_clips_tray_open` session key).
+
+---
+
+## Slice 6 — Read-only share links (PR #22)
+
+### Problem solved
+
+Per-clip **“anyone with the link”** read-only view without login; owner can create, copy, and revoke links. Public payload excludes private fields.
+
+### Backend
+
+| Area | Change |
+|------|--------|
+| Migration | `text_clip_shares` (token, soft-delete, one active share per clip) |
+| Model | `TextClipShare`; `TextClip#active_share`; `before_validation :assign_token` on create |
+| Owner API | `POST/DELETE .../text_clips/:id/share` (course + `users/self` scopes) |
+| Public | `GET /text_clips/shared/:token` — `SharedTextClipsController`, skip login; HTML + JSON |
+| Serializer | Owner JSON: `share: {token, url}`; public JSON omits `note`, tags, `user_id` |
+
+### Frontend
+
+| Area | Change |
+|------|--------|
+| API | `shareTextClip`, `unshareTextClip` (+ global variants) |
+| Tray | Per-clip share icon → Create link / Copy / Stop sharing; shared badge (course + global modes) |
+
+### Bug fixed during implementation
+
+Share creation returned **422** until token assignment moved to `before_validation :on => :create` (token was blank at validation time).
+
+`SharedTextClipsController` uses `preload` (not `includes`) and shard-aware clip lookup per Canvas conventions.
+
+### Issues referenced
+
+#5, #7, #10 (RSpec), #11 (Jest).
+
+### Automated QA (pre-merge)
+
+| Command | Result |
+|---------|--------|
+| `docker compose run --rm web bin/rspec spec/models/text_clip_share_spec.rb spec/controllers/text_clips_controller_spec.rb spec/controllers/shared_text_clips_controller_spec.rb` | 44 examples, 0 failures |
+| `yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx` | 39 tests, 0 failures |
+| `yarn check:ts` | pass |
+| `bin/rubocop` (touched Ruby) | no offenses |
+
+### Manual verification (Slice 6) — **PASSED 2026-06-02**
+
+Confirmed by developer in local Docker Canvas:
+
+1. **Create link** — Logged in → Text clips tray → share icon → Create link → URL `http://localhost:3000/text_clips/shared/<token>`; Copy works.
+2. **Logged-out view** — Incognito / no session → open share URL → see content, source, course name, saved date; **no** note, tags, edit UI, or other clips.
+3. **Revoke → 404** — Stop sharing in tray → reload share URL in incognito → **404** / not found.
+
+Optional API check:
+
+```bash
+curl -i "http://localhost:3000/text_clips/shared/TOKEN.json"
+```
+
+---
+
+## Dev environment (Docker) — lessons from Slice 5/6 testing
+
+### Start Canvas (keep running after closing terminal)
+
+```bash
+cd /path/to/canvas-lms
+docker compose up -d    # not bare `docker compose up` in foreground
+docker compose ps       # web, webpack, postgres, redis, jobs should be Up
+```
+
+### URL and login
+
+| Item | Value |
+|------|--------|
+| App URL | **http://localhost:3000** (`docker-compose.override.yml` maps `3000:80`) |
+| Dev user | `raylaser2@gmail.com` (Site Admin pseudonym, account_id=2) — use your local password |
+| Test course | **Text Clips Test** (course id `1`) |
+| Sample clip | id `1` (used during API curl checks) |
+
+### Frontend assets (why nav/JS sometimes “does nothing”)
+
+- Built JS lives in Docker volume **`canvas-lms_public_dist`**, not necessarily host `./public/dist`.
+- **`webpack` service** must be **Up** or run a one-shot build:
+
+```bash
+docker compose up -d webpack
+# if nav bundles missing or stale:
+docker compose run --rm web yarn webpack-development
+docker compose restart web
+```
+
+- Hard refresh browser: **Ctrl+Shift+R** (Cmd+Shift+R on Mac).
+
+### `instui_nav` feature flag
+
+- Text clips in **InstUI** `SideNav` only apply when `ENV.FEATURES.instui_nav === true` **and** navigation_header JS runs.
+- Enabled on accounts **1** (TextClipDev) and **2** (Site Admin) in dev.
+- Stale Redis cache can serve `instui_nav: false` in the browser even when DB says on. Clear keys:
+
+```bash
+docker compose exec -T redis redis-cli --scan --pattern 'rails80:js_env_account_features*' \
+  | xargs -r docker compose exec -T redis redis-cli DEL
+```
+
+Then hard refresh. Console check: `ENV.FEATURES.instui_nav`.
+
+### Why classic nav appeared without Text clips
+
+Classic left nav is server-rendered (`app/views/shared/_new_nav_header.html.erb`). InstUI `SideNav` replaces `#header` only when `instui_nav` JS loads. Typical causes: webpack stopped, stale `js_env` cache, or flag off in ENV.
+
+---
+
+## Follow-up work — nav visibility (local, not yet merged)
+
+Uncommitted fixes on dev machine (2026-06-02) so **Text clips** appears in classic nav and opens the tray without relying on InstUI alone:
+
+| File | Change |
+|------|--------|
+| `app/views/shared/_new_nav_header.html.erb` | “Text clips” menu item above Help (`#global_nav_text_clips_link`) |
+| `ui/features/navigation_header/react/OldSideNav.tsx` | `text_clips` tray type + lazy `TextClipsTray` |
+| `ui/features/navigation_header/react/utils.ts` | `getTrayLabel` for `text_clips` |
+| `ui/features/navigation_header/index.tsx` | When `instui_nav`, mount `SideNav` into `#header` (not only hidden mobile container) |
+| `app/stylesheets/base/_SideNav.scss` | `#text-clips-tray` styling |
+| `config/feature_flags/app_fundamentals_release_flags.yml` | `instui_nav` `development: allowed_on` |
+
+**Status:** Verified locally (“Text clips” visible above Help). **Next step:** commit on a branch + PR when ready.
+
+```bash
+git status   # should list the files above if not yet committed
+```
+
+---
+
+## Commands cheat sheet
+
+```bash
+# Ruby tests (full text-clipper-related set as of slice 6)
+docker compose run --rm web bin/rspec \
+  spec/models/text_clip_spec.rb \
+  spec/models/text_clip_share_spec.rb \
+  spec/controllers/text_clips_controller_spec.rb \
+  spec/controllers/shared_text_clips_controller_spec.rb
+
+# JS tests
+docker compose run --rm web yarn test ui/features/text_clips \
+  ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+
+# Typecheck / lint
+docker compose run --rm web yarn check:ts
+docker compose run --rm web bin/rubocop app/models/text_clip*.rb app/controllers/text_clips_controller.rb app/controllers/shared_text_clips_controller.rb
+```
+
+---
+
+## Key files index (Slice 5 + 6)
+
+| Concern | Paths |
+|---------|--------|
+| Global API | `app/controllers/text_clips_controller.rb`, `config/routes.rb`, `lib/api/v1/text_clip.rb` |
+| Share API | `app/models/text_clip_share.rb`, `app/controllers/shared_text_clips_controller.rb`, `app/views/shared_text_clips/show.html.erb` |
+| Tray UI | `ui/features/navigation_header/react/trays/TextClipsTray.tsx` |
+| InstUI nav | `ui/features/navigation_header/react/SideNav.tsx`, `index.tsx` |
+| Classic nav | `app/views/shared/_new_nav_header.html.erb`, `OldSideNav.tsx` |
+| Client API | `ui/features/text_clips/api.ts`, `types.ts` |
+| Selection save | `ui/features/text_clips/index.tsx` |
+| Layout bundle | `app/views/layouts/application.html.erb`, `app/views/layouts/_head.html.erb` |
+
+---
+
+## What is not done yet (project backlog)
+
+Per [`agents/project-creation.md`](../../project-creation.md) and [`implementation-research.md`](implementation-research.md):
+
+- Remaining stories (e.g. full Story 10 coverage, FR items not in slices 1–6)
+- Merge **nav visibility** follow-up (table above)
+- Optional: dedicated `/text_clips` page (deferred from slice 5 plan)
+- Production hardening, feature flag rollout, instructor board alignment via GitHub UI
+
+---
+
+## Agent workflow reminders
+
+- Implementation: [`agents/feature-implementation.md`](../../feature-implementation.md)
+- QA gate: [`agents/quality-assurance.md`](../../quality-assurance.md)
+- Fork only: `THAT-ON3-GUY/canvas-lms`; integration branch **`master`**
+- Commit message format: see root `AGENTS.md` / `CLAUDE.md` (ChangeId, `refs`/`closes`, `flag=`, test plan)
+
+---
+
+*Last updated: 2026-06-02 — after Slice 6 merge, manual share-link QA pass, and local nav fix verification.*

--- a/agents/tasks/feature-1/qa-lab-evidence.md
+++ b/agents/tasks/feature-1/qa-lab-evidence.md
@@ -1,5 +1,7 @@
 # QA lab evidence — Lab 4.1 (Canvas Text Clipper)
 
+**Slice 5+ narrative, dev environment, manual sign-off:** [`progress-slice-5-onward.md`](progress-slice-5-onward.md).
+
 ## Work items
 
 | Item | PR | Tests added / updated | Command | Outcome | Trace |
@@ -61,3 +63,23 @@ Manual checklist: [`.cursor/plans/text_clipper_slice_6_31ac498c.plan.md`](../../
 | When (UTC) | Status | Method |
 |------------|--------|--------|
 | 2026-06-02 | Done | PR #22 squash-merged to `master` |
+
+### Manual verification (Slice 6) — signed off
+
+| Step | Expected | Result (2026-06-02) |
+|------|----------|---------------------|
+| Create link from tray | URL `/text_clips/shared/<token>`, copy works | **Pass** (developer) |
+| Open link logged out | Content + source + course + date; no note/tags/edit | **Pass** |
+| Stop sharing + reload | 404 | **Pass** |
+
+Recorded in [`progress-slice-5-onward.md`](progress-slice-5-onward.md). API-only verification was also run earlier via `curl` / Rails runner during agent session.
+
+## Slice 5+ dev UI QA (nav visibility)
+
+| Check | Result (2026-06-02) |
+|-------|---------------------|
+| Text clips entry in left global nav | **Pass** after classic ERB item + `OldSideNav` wiring + `docker compose up -d` + Redis cache clear + webpack |
+| Tray opens from nav click | **Pass** |
+| Share flow still works end-to-end | **Pass** (same session as Slice 6 manual checklist) |
+
+Follow-up: commit nav files listed in [`progress-slice-5-onward.md`](progress-slice-5-onward.md) § Follow-up work.

--- a/app/stylesheets/base/_SideNav.scss
+++ b/app/stylesheets/base/_SideNav.scss
@@ -60,6 +60,7 @@
 #calendar-tray,
 #conversations-tray,
 #history-tray,
+#text-clips-tray,
 #help-tray,
 [id$="-external-tool-tray"] {
   align-items: center;

--- a/app/views/shared/_new_nav_header.html.erb
+++ b/app/views/shared/_new_nav_header.html.erb
@@ -223,6 +223,18 @@
       <% unless @current_user.nil? %>
         <%= render(partial: 'external_tools/global_nav_menu_items') %>
       <% end %>
+      <% if @current_user %>
+        <li class="menu-item ic-app-header__menu-list-item">
+          <a id="global_nav_text_clips_link" role="button" href="#" class="ic-app-header__menu-list-link">
+            <div class="menu-item-icon-container" aria-hidden="true">
+              <%= render(partial: "shared/svg/svg_icon_folder", formats: [:svg]) %>
+            </div>
+            <div class="menu-item__text">
+              <%= t('Text clips', :scope => :text_clips) %>
+            </div>
+          </a>
+        </li>
+      <% end %>
       <li class="ic-app-header__menu-list-item">
         <%= link_to "#",  # gets overridden by JS to this anyway, and also there is a click action to slide out the help tray
                     :id => 'global_nav_help_link',

--- a/config/feature_flags/app_fundamentals_release_flags.yml
+++ b/config/feature_flags/app_fundamentals_release_flags.yml
@@ -31,6 +31,9 @@ instui_nav:
   applies_to: RootAccount
   display_name: New InstUI navbar
   description: This is a new navbar being implemented with react router in mind
+  environments:
+    development:
+      state: allowed_on
 password_complexity:
   state: hidden
   applies_to: RootAccount

--- a/ui/features/navigation_header/index.tsx
+++ b/ui/features/navigation_header/index.tsx
@@ -76,16 +76,19 @@ if (window.ENV.FEATURES.instui_nav || localStorage.instui_nav_dev) {
 ready(() => {
   const showInstUiNavbar = window.ENV.FEATURES.instui_nav || localStorage.instui_nav_dev
   if (showInstUiNavbar) {
-    const mobileContextNavContainer = document.getElementById('mobileContextNavContainer')
-    if (mobileContextNavContainer) {
+    const header = document.getElementById('header')
+    if (header) {
+      header.innerHTML = ''
       render(
         <QueryClientProvider client={queryClient}>
           <SideNav externalTools={getExternalTools()} />
         </QueryClientProvider>,
-        mobileContextNavContainer,
+        header,
       )
+    }
 
-      // Render MobileNavigation after SideNav
+    const mobileContextNavContainer = document.getElementById('mobileContextNavContainer')
+    if (mobileContextNavContainer) {
       render(
         <QueryClientProvider client={queryClient}>
           <AlertManager>

--- a/ui/features/navigation_header/react/OldSideNav.tsx
+++ b/ui/features/navigation_header/react/OldSideNav.tsx
@@ -40,6 +40,7 @@ const GroupsTray = React.lazy(() => import('./trays/GroupsTray'))
 const AccountsTray = React.lazy(() => import('./trays/AccountsTray'))
 const ProfileTray = React.lazy(() => import('./trays/ProfileTray'))
 const HistoryTray = React.lazy(() => import('./trays/HistoryTray'))
+const TextClipsTray = React.lazy(() => import('./trays/TextClipsTray'))
 const HelpTray = React.lazy(() => import('./trays/HelpTray'))
 
 const accountsNavLink = document.querySelector(`#global_nav_accounts_link`)
@@ -61,10 +62,19 @@ type ActiveItem =
   | 'groups'
   | 'profile'
   | 'history'
+  | 'text_clips'
   | 'help'
   | null
 
-const itemsWithResources = ['courses', 'groups', 'accounts', 'profile', 'history', 'help'] as const
+const itemsWithResources = [
+  'courses',
+  'groups',
+  'accounts',
+  'profile',
+  'history',
+  'text_clips',
+  'help',
+] as const
 
 function noop() {}
 
@@ -234,6 +244,7 @@ const Navigation = () => {
               {type === 'accounts' && <AccountsTray />}
               {type === 'profile' && <ProfileTray />}
               {type === 'history' && <HistoryTray />}
+              {type === 'text_clips' && <TextClipsTray />}
               {type === 'help' && <HelpTray closeTray={closeTray} />}
             </React.Suspense>
           </div>

--- a/ui/features/navigation_header/react/utils.ts
+++ b/ui/features/navigation_header/react/utils.ts
@@ -104,6 +104,7 @@ export function getTrayLabel(type: string | null) {
     case 'history':
       return I18n.t('Recent History tray')
     case 'textClips':
+    case 'text_clips':
       return I18n.t('Text clips tray')
     default:
       return I18n.t('Global navigation tray')


### PR DESCRIPTION
## Summary

- Add **Text clips** to classic global nav and wire **OldSideNav** to open `TextClipsTray`.
- Mount InstUI **SideNav** into `#header` when `instui_nav` is enabled.
- Allow `instui_nav` in development via feature flag YAML.
- Add **`agents/tasks/feature-1/progress-slice-5-onward.md`** (Slice 5+ reference, manual QA, Docker notes).
- Update lab evidence files with cross-links and sign-off.

## Test plan

- [x] Text clips in left nav; tray opens
- [x] Slice 6 share manual checklist passed locally
- [ ] `git pull` on other machine; reference progress doc in Cursor


Made with [Cursor](https://cursor.com)