### PR TITLE
Slice 9: Highlight restore on clip source pages

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -13,6 +13,7 @@
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/23 | **Nav + progress doc:** classic nav Text clips entry, OldSideNav tray, InstUI header mount, `progress-slice-5-onward.md`. Merge `4b1ada9aebb`. |
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/24 | **Slice 7 — Core close-out:** `TextClipsSelectionRoot` Jest (FR-01/FR-07), index newest-first RSpec, Story 12 manual checklist, closed issues #5–#16. Closes #10, #11, #12. Merge: `28654a2ce0f`. |
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/25 | **Slice 8 — Full-page /text_clips:** `TextClipsPagesController`, `text_clips_page` bundle, reuses `TextClipsTray` in global mode, “View all clips” tray link. Merge: `cf75128c12e`. |
+| https://github.com/THAT-ON3-GUY/canvas-lms/pull/26 | **Slice 9 — Highlight restore:** `highlightRestore.ts`, source links carry `#text_clip_highlight=`, bundle retries on page load. Frontend-only. |
 
 ## Board: item titles and status timeline
 
@@ -193,3 +194,16 @@ Closes the original **Testing & Verification** milestone and FR-01–FR-07 accep
 ### Trace
 
 Deferred full-page manager from Slice 5 plan; no new API or migrations.
+
+## Slice 9 — Highlight restoration on source pages
+
+### Scope delivered
+
+- **Module:** [`ui/features/text_clips/highlightRestore.ts`](../../../ui/features/text_clips/highlightRestore.ts) — `buildHighlightHash`, `parseHighlightTarget`, `findTextRange`, `applyHighlight` (CSS Custom Highlight API + scroll fallback), `scheduleHighlightRestore`
+- **Bundle:** [`ui/features/text_clips/index.tsx`](../../../ui/features/text_clips/index.tsx) calls `scheduleHighlightRestore()` after selection root render (retries for late DOM)
+- **Tray:** [`TextClipsTray.tsx`](../../../ui/features/navigation_header/react/trays/TextClipsTray.tsx) source `Link` uses `sourceUrlWithHighlight(clip)` so opening source re-highlights clipped text
+- **Tests:** [`highlightRestore.test.ts`](../../../ui/features/text_clips/__tests__/highlightRestore.test.ts); tray source `href` fragment assertion
+
+### Trace
+
+Frontend-only; no API, controller, or migration changes. First-match only; graceful info flash when text is missing on the page.

--- a/agents/tasks/feature-1/progress-slice-5-onward.md
+++ b/agents/tasks/feature-1/progress-slice-5-onward.md
@@ -261,6 +261,16 @@ docker compose run --rm web bin/rubocop app/models/text_clip*.rb app/controllers
 
 **Manual check:** Log in → open Text clips tray → click **View all clips** → confirm full-page list, search, tags, share work.
 
+## Slice 9 — Highlight restore on source pages (2026-06-04)
+
+| Item | Detail |
+|------|--------|
+| PR | [#26](https://github.com/THAT-ON3-GUY/canvas-lms/pull/26) |
+| UX | Tray/full-page **source** link appends `#text_clip_highlight=<snippet>`; destination page scrolls + ~4s yellow highlight |
+| Miss | Info flash: “Couldn't find the clipped text on this page” |
+
+**Manual check:** Clip text on a course page → tray → open source link → page scrolls/highlights; edit page to remove text → open source → info flash (no error).
+
 ## What is not done yet (project backlog)
 
 Per [`agents/project-creation.md`](../../project-creation.md):
@@ -278,4 +288,4 @@ Per [`agents/project-creation.md`](../../project-creation.md):
 
 ---
 
-*Last updated: 2026-06-04 — Slice 8 full-page /text_clips.*
+*Last updated: 2026-06-04 — Slice 9 highlight restore on source pages.*

--- a/agents/tasks/feature-1/qa-lab-evidence.md
+++ b/agents/tasks/feature-1/qa-lab-evidence.md
@@ -13,6 +13,7 @@
 | **Slice 6** — Read-only share links | https://github.com/THAT-ON3-GUY/canvas-lms/pull/22 | `text_clip_shares` migration/model; `share`/`unshare` + `SharedTextClipsController`; tray share UI; API helpers | `docker compose run --rm web bin/rspec spec/models/text_clip_share_spec.rb spec/controllers/text_clips_controller_spec.rb spec/controllers/shared_text_clips_controller_spec.rb`; `yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx`; `yarn check:ts` | **44 RSpec examples, 0 failures**; **39 Jest tests, 0 failures**; rubocop clean on touched Ruby | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/b9dfadfcbad4521e902ffb387825ab205d9aeeec |
 | **Slice 7** — Core close-out | https://github.com/THAT-ON3-GUY/canvas-lms/pull/24 | `TextClipsSelectionRoot.test.tsx`; `manual-verification-checklist.md`; index newest-first RSpec; closed issues #5–#16 | `yarn test ui/features/text_clips`; `bin/rspec spec/controllers/text_clips_controller_spec.rb` | **44 Jest**, **38 RSpec**, 0 failures; `yarn check:ts` pass | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/28654a2ce0f |
 | **Slice 8** — Full-page /text_clips | https://github.com/THAT-ON3-GUY/canvas-lms/pull/25 | `TextClipsPagesController`, `text_clips_page` bundle, tray reuse, View all clips link | `yarn test ui/features/text_clips_page`; `bin/rspec spec/controllers/text_clips_pages_controller_spec.rb` | **25 Jest**, **2 RSpec**, 0 failures | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/cf75128c12e |
+| **Slice 9** — Highlight restore | https://github.com/THAT-ON3-GUY/canvas-lms/pull/26 | `highlightRestore.ts`, bundle hook, tray source href fragment | `yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx`; `yarn check:ts` | **54 Jest**, 0 failures | PR #26 |
 
 ## Board / issue timeline (#2)
 
@@ -115,3 +116,14 @@ Manual checklist: [`manual-verification-checklist.md`](manual-verification-check
 | When (UTC) | Status | Method |
 |------------|--------|--------|
 | 2026-06-04 | Done | PR #25 squash-merged to `master` |
+
+## Slice 9 QA (highlight restore)
+
+| Command | Outcome |
+|---------|---------|
+| `docker compose run --rm web yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx` | **54 tests, 0 failures** |
+| `docker compose run --rm web yarn check:ts` | pass |
+
+| When (UTC) | Status | Method |
+|------------|--------|--------|
+| 2026-06-04 | Done | PR #26 squash-merged to `master` |

--- a/ui/features/navigation_header/react/trays/TextClipsTray.tsx
+++ b/ui/features/navigation_header/react/trays/TextClipsTray.tsx
@@ -58,6 +58,7 @@ import {
   updateGlobalTextClip,
   updateTextClip,
 } from '../../../text_clips/api'
+import {sourceUrlWithHighlight} from '../../../text_clips/highlightRestore'
 import {CLIP_TAG_PALETTE, CLIP_TAG_THEME} from '../../../text_clips/tagColors'
 import type {
   ClipTagColor,
@@ -276,7 +277,7 @@ function TextClipListItem({
               {clip.source_url && (
                 <Link
                   isWithinText={false}
-                  href={clip.source_url}
+                  href={sourceUrlWithHighlight(clip) ?? clip.source_url}
                   target="_blank"
                   rel="noopener noreferrer"
                   data-testid={`text-clip-source-${clip.id}`}

--- a/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+++ b/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
@@ -113,6 +113,8 @@ describe('TextClipsTray', () => {
     await waitFor(() =>
       expect(screen.getByTestId('text-clip-source-1')).toHaveTextContent('Week 1 Page'),
     )
+    const sourceLink = screen.getByTestId('text-clip-source-1').closest('a')
+    expect(sourceLink).toHaveAttribute('href', expect.stringMatching(/#text_clip_highlight=alpha/))
     await user.click(screen.getByTestId('text-clip-delete-1'))
     await waitFor(() => expect(screen.getByText(/No clips yet/i)).toBeInTheDocument())
   })

--- a/ui/features/text_clips/__tests__/highlightRestore.test.ts
+++ b/ui/features/text_clips/__tests__/highlightRestore.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {showFlashAlert} from '@instructure/platform-alerts'
+import {
+  HIGHLIGHT_PARAM,
+  applyHighlight,
+  buildHighlightHash,
+  findTextRange,
+  parseHighlightTarget,
+  restoreHighlightFromLocation,
+} from '../highlightRestore'
+
+vi.mock('@instructure/platform-alerts', () => ({
+  showFlashAlert: vi.fn(),
+}))
+
+const showFlashAlertMock = vi.mocked(showFlashAlert)
+
+describe('highlightRestore hash helpers', () => {
+  it('round-trips buildHighlightHash and parseHighlightTarget', () => {
+    const text = 'Hello   world\nfrom  clip'
+    const hash = buildHighlightHash(text)
+    expect(hash).toMatch(new RegExp(`^#${HIGHLIGHT_PARAM}=`))
+    expect(parseHighlightTarget({hash})).toBe('Hello world from clip')
+  })
+
+  it('ignores unrelated hash fragments', () => {
+    expect(parseHighlightTarget({hash: '#section-2'})).toBeNull()
+    expect(parseHighlightTarget({hash: ''})).toBeNull()
+  })
+})
+
+describe('findTextRange', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('matches within a single text node', () => {
+    document.body.innerHTML = '<p>Find me in the paragraph.</p>'
+    const range = findTextRange(document.body, 'Find me')
+    expect(range).not.toBeNull()
+    expect(range?.toString()).toBe('Find me')
+  })
+
+  it('matches across element boundaries with normalized whitespace', () => {
+    document.body.innerHTML = '<p>Hello <span>  world</span>!</p>'
+    const range = findTextRange(document.body, 'Hello world')
+    expect(range).not.toBeNull()
+    expect(range?.toString().replace(/\s+/g, ' ').trim()).toBe('Hello world')
+  })
+
+  it('returns null when the needle is not present', () => {
+    document.body.innerHTML = '<p>Nothing here</p>'
+    expect(findTextRange(document.body, 'missing text')).toBeNull()
+  })
+
+  it('skips content inside editors', () => {
+    document.body.innerHTML =
+      '<p>Visible text</p><div class="tox-edit-area"><p>Hidden editor text</p></div>'
+    expect(findTextRange(document.body, 'Hidden editor text')).toBeNull()
+    expect(findTextRange(document.body, 'Visible text')).not.toBeNull()
+  })
+})
+
+describe('restoreHighlightFromLocation', () => {
+  let scrollIntoView: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    document.body.innerHTML = '<p>Target phrase for highlight.</p>'
+    showFlashAlertMock.mockReset()
+    vi.stubGlobal('location', {hash: buildHighlightHash('Target phrase')})
+    scrollIntoView = vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    scrollIntoView.mockRestore()
+    vi.unstubAllGlobals()
+    if (typeof CSS !== 'undefined' && CSS.highlights) {
+      CSS.highlights.clear()
+    }
+  })
+
+  it('scrolls and registers a highlight when text is found', () => {
+    const highlights = new Map<string, unknown>()
+    class MockHighlight {
+      constructor(public ranges: unknown[]) {}
+    }
+    vi.stubGlobal('Highlight', MockHighlight)
+    vi.stubGlobal('CSS', {
+      highlights: {
+        set: (name: string, value: unknown) => highlights.set(name, value),
+        delete: (name: string) => highlights.delete(name),
+      },
+    })
+
+    const found = restoreHighlightFromLocation()
+    expect(found).toBe(true)
+    expect(scrollIntoView).toHaveBeenCalled()
+    expect(highlights.has('text-clip')).toBe(true)
+    expect(showFlashAlertMock).not.toHaveBeenCalled()
+  })
+
+  it('shows an info flash when text is not found', () => {
+    document.body.innerHTML = '<p>Other content</p>'
+    const found = restoreHighlightFromLocation({showMissFlash: true})
+    expect(found).toBe(false)
+    expect(showFlashAlertMock).toHaveBeenCalledWith(expect.objectContaining({type: 'info'}))
+  })
+})
+
+describe('applyHighlight', () => {
+  it('scrolls when CSS highlights are unavailable', () => {
+    document.body.innerHTML = '<p>Scroll target</p>'
+    const range = findTextRange(document.body, 'Scroll target')
+    expect(range).not.toBeNull()
+    const scrollIntoView = vi
+      .spyOn(HTMLElement.prototype, 'scrollIntoView')
+      .mockImplementation(() => {})
+    vi.stubGlobal('CSS', undefined)
+
+    applyHighlight(range as Range)
+    expect(scrollIntoView).toHaveBeenCalled()
+    scrollIntoView.mockRestore()
+  })
+})

--- a/ui/features/text_clips/highlightRestore.ts
+++ b/ui/features/text_clips/highlightRestore.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {useScope as createI18nScope} from '@canvas/i18n'
+import {showFlashAlert} from '@instructure/platform-alerts'
+import type {TextClipRecord} from './types'
+
+const I18n = createI18nScope('text_clips')
+
+export const HIGHLIGHT_PARAM = 'text_clip_highlight'
+const HIGHLIGHT_NAME = 'text-clip'
+const HIGHLIGHT_STYLE_ID = 'text-clip-highlight-style'
+const SNIPPET_MAX_LENGTH = 300
+const HIGHLIGHT_CLEAR_MS = 4000
+
+const EDITOR_SKIP_SELECTOR =
+  '.tox-edit-area, .CodeMirror, .ql-editor, .RceWrapper, [contenteditable="true"], script, style, noscript'
+
+type CharMapEntry = {node: Text; offset: number}
+
+function normalizeNeedle(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+export function buildHighlightHash(text: string): string {
+  const snippet = normalizeNeedle(text).slice(0, SNIPPET_MAX_LENGTH)
+  return `#${HIGHLIGHT_PARAM}=${encodeURIComponent(snippet)}`
+}
+
+export function parseHighlightTarget(loc: {hash: string}): string | null {
+  const raw = loc.hash.replace(/^#/, '')
+  if (!raw.startsWith(`${HIGHLIGHT_PARAM}=`)) return null
+  try {
+    const decoded = decodeURIComponent(raw.slice(HIGHLIGHT_PARAM.length + 1))
+    return decoded ? normalizeNeedle(decoded) : null
+  } catch (_e) {
+    return null
+  }
+}
+
+export function sourceUrlWithHighlight(
+  clip: Pick<TextClipRecord, 'source_url' | 'content'>,
+): string | null {
+  if (!clip.source_url) return null
+  const hash = buildHighlightHash(clip.content)
+  try {
+    const url = new URL(clip.source_url, window.location.origin)
+    url.hash = hash.replace(/^#/, '')
+    return url.toString()
+  } catch (_e) {
+    const base = clip.source_url.split('#')[0]
+    return `${base}${hash}`
+  }
+}
+
+function nodeInsideSkippedEditor(node: Node): boolean {
+  const el =
+    node.nodeType === Node.ELEMENT_NODE ? (node as Element) : (node.parentElement as Element | null)
+  if (!el) return true
+  return Boolean(el.closest(EDITOR_SKIP_SELECTOR))
+}
+
+function buildSearchIndex(root: Node): {haystack: string; map: CharMapEntry[]} {
+  const map: CharMapEntry[] = []
+  let haystack = ''
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  let textNode = walker.nextNode() as Text | null
+  while (textNode) {
+    if (!nodeInsideSkippedEditor(textNode)) {
+      const value = textNode.nodeValue ?? ''
+      for (let i = 0; i < value.length; i += 1) {
+        const ch = value[i]
+        if (/\s/.test(ch)) {
+          if (haystack.length > 0 && haystack[haystack.length - 1] !== ' ') {
+            haystack += ' '
+            map.push({node: textNode, offset: i})
+          }
+        } else {
+          haystack += ch
+          map.push({node: textNode, offset: i})
+        }
+      }
+    }
+    textNode = walker.nextNode() as Text | null
+  }
+  return {haystack, map}
+}
+
+export function findTextRange(root: Node, needle: string): Range | null {
+  const normalizedNeedle = normalizeNeedle(needle)
+  if (!normalizedNeedle) return null
+
+  const {haystack, map} = buildSearchIndex(root)
+  const startIndex = haystack.indexOf(normalizedNeedle)
+  if (startIndex < 0 || map.length === 0) return null
+
+  const endIndex = startIndex + normalizedNeedle.length - 1
+  const startEntry = map[startIndex]
+  const endEntry = map[endIndex]
+  if (!startEntry || !endEntry) return null
+
+  const range = document.createRange()
+  range.setStart(startEntry.node, startEntry.offset)
+  range.setEnd(endEntry.node, endEntry.offset + 1)
+  return range
+}
+
+function ensureHighlightStyle() {
+  if (document.getElementById(HIGHLIGHT_STYLE_ID)) return
+  const style = document.createElement('style')
+  style.id = HIGHLIGHT_STYLE_ID
+  style.textContent = `::highlight(${HIGHLIGHT_NAME}) { background-color: rgba(255, 214, 0, 0.55); }`
+  document.head.appendChild(style)
+}
+
+let clearHighlightTimer: number | undefined
+
+function clearActiveHighlight() {
+  if (clearHighlightTimer) {
+    window.clearTimeout(clearHighlightTimer)
+    clearHighlightTimer = undefined
+  }
+  if (typeof CSS !== 'undefined' && CSS.highlights) {
+    CSS.highlights.delete(HIGHLIGHT_NAME)
+  }
+}
+
+function scrollTargetForRange(range: Range): Element | null {
+  let node: Node | null = range.startContainer
+  if (node.nodeType === Node.TEXT_NODE) {
+    node = node.parentElement ?? node.parentNode
+  }
+  return node instanceof Element ? node : null
+}
+
+export function applyHighlight(range: Range): void {
+  clearActiveHighlight()
+
+  scrollTargetForRange(range)?.scrollIntoView({behavior: 'smooth', block: 'center'})
+
+  if (typeof CSS !== 'undefined' && CSS.highlights && typeof Highlight !== 'undefined') {
+    ensureHighlightStyle()
+    const highlight = new Highlight(range)
+    CSS.highlights.set(HIGHLIGHT_NAME, highlight)
+    clearHighlightTimer = window.setTimeout(() => clearActiveHighlight(), HIGHLIGHT_CLEAR_MS)
+    return
+  }
+
+  clearHighlightTimer = window.setTimeout(() => clearActiveHighlight(), HIGHLIGHT_CLEAR_MS)
+}
+
+export function restoreHighlightFromLocation(options?: {
+  location?: Pick<Location, 'hash'>
+  showMissFlash?: boolean
+}): boolean {
+  const loc = options?.location ?? window.location
+  const needle = parseHighlightTarget(loc)
+  if (!needle) return false
+
+  const range = findTextRange(document.body, needle)
+  if (!range) {
+    if (options?.showMissFlash) {
+      showFlashAlert({
+        type: 'info',
+        message: I18n.t("Couldn't find the clipped text on this page"),
+      })
+    }
+    return false
+  }
+
+  applyHighlight(range)
+  return true
+}
+
+export function scheduleHighlightRestore(maxAttempts = 4) {
+  if (!parseHighlightTarget(window.location)) return
+
+  let attempt = 0
+  const tryRestore = () => {
+    if (restoreHighlightFromLocation({location: window.location, showMissFlash: false})) {
+      return
+    }
+    attempt += 1
+    if (attempt < maxAttempts) {
+      window.setTimeout(tryRestore, 300 * attempt)
+    } else {
+      restoreHighlightFromLocation({location: window.location, showMissFlash: true})
+    }
+  }
+
+  tryRestore()
+}

--- a/ui/features/text_clips/index.tsx
+++ b/ui/features/text_clips/index.tsx
@@ -19,6 +19,7 @@
 import {render} from '@canvas/react'
 import ready from '@instructure/ready'
 import TextClipsSelectionRoot from './components/TextClipsSelectionRoot'
+import {scheduleHighlightRestore} from './highlightRestore'
 
 ready(() => {
   let mount = document.getElementById('text-clips-selection-mount')
@@ -28,4 +29,5 @@ ready(() => {
     document.body.appendChild(mount)
   }
   render(<TextClipsSelectionRoot />, mount)
+  scheduleHighlightRestore()
 })


### PR DESCRIPTION
## Summary

- Add `highlightRestore.ts` to re-find clipped text on source pages via `#text_clip_highlight=` URL fragment
- Hook `scheduleHighlightRestore()` into the always-loaded `text_clips` bundle (with retries for late DOM)
- Tray/full-page source links use `sourceUrlWithHighlight(clip)` so opening source scrolls and briefly highlights text
- Jest coverage for hash round-trip, findTextRange, restore miss flash, and tray href fragment

Frontend-only; no API, controller, or migration changes.

## Test plan

- [x] `yarn test ui/features/text_clips` + `TextClipsTray.test.tsx` (54 tests)
- [x] `yarn check:ts`
- [ ] Manual: clip text → tray source link → scroll + highlight
- [ ] Manual: remove text on page → source link → info flash

flag=none

Made with [Cursor](https://cursor.com)