### PR TITLE
Slice 11: Rich-content text clipping

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -15,6 +15,7 @@
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/25 | **Slice 8 — Full-page /text_clips:** `TextClipsPagesController`, `text_clips_page` bundle, reuses `TextClipsTray` in global mode, “View all clips” tray link. Merge: `cf75128c12e`. |
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/26 | **Slice 9 — Highlight restore:** `highlightRestore.ts`, source links carry `#text_clip_highlight=`, bundle retries on page load. Frontend-only. Merge: `751a8a30c8c`. |
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/27 | **Slice 10 — Pin & sort:** `pinned_at` column, `ordered` scope, tray sort select + pin button. Merge: `668650a4277`. |
+| https://github.com/THAT-ON3-GUY/canvas-lms/pull/28 | **Slice 11 — Rich-content clipping:** `content_html` column, sanitized HTML capture + render in tray/shared view. |
 
 ## Board: item titles and status timeline
 
@@ -221,3 +222,16 @@ Frontend-only; no API, controller, or migration changes. First-match only; grace
 ### Trace
 
 Multi-tag filter unchanged (OR via `tag_ids[]`). Pin toggle uses existing PUT; no new routes.
+
+## Slice 11 — Rich-content clipping
+
+### Scope delivered
+
+- **Migration:** `content_html` on `text_clips` ([`20260604083000_add_content_html_to_text_clips.rb`](../../../db/migrate/20260604083000_add_content_html_to_text_clips.rb))
+- **Model:** `sanitize_field :content_html, CanvasSanitize::SANITIZE`; plain `content` unchanged for search
+- **Capture:** [`getSelectedHtml`](../../../ui/features/text_clips/selectionUtils.ts) + [`TextClipsSelectionRoot`](../../../ui/features/text_clips/components/TextClipsSelectionRoot.tsx) posts `content_html` when selection has tags
+- **Render:** tray/full page rich block; [`shared_text_clips/show.html.erb`](../../../app/views/shared_text_clips/show.html.erb) uses sanitized HTML
+
+### Trace
+
+Edit mode stays plain text; saving content without `content_html` clears stored HTML. Backward compatible for existing clips.

--- a/agents/tasks/feature-1/progress-slice-5-onward.md
+++ b/agents/tasks/feature-1/progress-slice-5-onward.md
@@ -281,6 +281,16 @@ docker compose run --rm web bin/rubocop app/models/text_clip*.rb app/controllers
 
 **Manual check:** Pin a clip → it stays at top when sorting; unpin → normal order; sort Oldest/Source updates list (pinned still first).
 
+## Slice 11 — Rich-content clipping (2026-06-04)
+
+| Item | Detail |
+|------|--------|
+| PR | [#28](https://github.com/THAT-ON3-GUY/canvas-lms/pull/28) |
+| UX | Clipping bold/links/lists preserves formatting in tray, full page, and shared link |
+| API | `POST/PUT` accepts `content_html`; JSON includes sanitized `content_html` |
+
+**Manual check:** Clip formatted text → tray shows HTML; share link renders formatting; edit plain text → rich view clears.
+
 ## What is not done yet (project backlog)
 
 Per [`agents/project-creation.md`](../../project-creation.md):
@@ -298,4 +308,4 @@ Per [`agents/project-creation.md`](../../project-creation.md):
 
 ---
 
-*Last updated: 2026-06-04 — Slice 10 pin & sort clips.*
+*Last updated: 2026-06-04 — Slice 11 rich-content clipping.*

--- a/agents/tasks/feature-1/qa-lab-evidence.md
+++ b/agents/tasks/feature-1/qa-lab-evidence.md
@@ -15,6 +15,7 @@
 | **Slice 8** — Full-page /text_clips | https://github.com/THAT-ON3-GUY/canvas-lms/pull/25 | `TextClipsPagesController`, `text_clips_page` bundle, tray reuse, View all clips link | `yarn test ui/features/text_clips_page`; `bin/rspec spec/controllers/text_clips_pages_controller_spec.rb` | **25 Jest**, **2 RSpec**, 0 failures | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/cf75128c12e |
 | **Slice 9** — Highlight restore | https://github.com/THAT-ON3-GUY/canvas-lms/pull/26 | `highlightRestore.ts`, bundle hook, tray source href fragment | `yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx`; `yarn check:ts` | **54 Jest**, 0 failures | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/751a8a30c8cd83141c5463880589d4fbbd74df74 |
 | **Slice 10** — Pin & sort | https://github.com/THAT-ON3-GUY/canvas-lms/pull/27 | `pinned_at` migration, `ordered` scope, tray sort + pin UI | `bin/rspec spec/controllers/text_clips_controller_spec.rb spec/models/text_clip_spec.rb`; `yarn test` text_clips + tray; `yarn check:ts` | **67 RSpec**, **57 Jest**, 0 failures | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/668650a4277e7d06987c8c7877bcf31aab68d6e4 |
+| **Slice 11** — Rich-content clipping | https://github.com/THAT-ON3-GUY/canvas-lms/pull/28 | `content_html` migration, sanitize_field, capture + tray/shared render | `bin/rspec` + `yarn test` text_clips + tray; `yarn check:ts` | **70 RSpec**, **61 Jest**, 0 failures | PR #28 |
 
 ## Board / issue timeline (#2)
 
@@ -141,3 +142,15 @@ Manual checklist: [`manual-verification-checklist.md`](manual-verification-check
 | When (UTC) | Status | Method |
 |------------|--------|--------|
 | 2026-06-04 | Done | PR #27 squash-merged to `master` |
+
+## Slice 11 QA (rich-content clipping)
+
+| Command | Outcome |
+|---------|---------|
+| `docker compose run --rm web bin/rspec spec/controllers/text_clips_controller_spec.rb spec/models/text_clip_spec.rb` | **70 examples, 0 failures** |
+| `docker compose run --rm web yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx` | **61 tests, 0 failures** |
+| `docker compose run --rm web yarn check:ts` | pass |
+
+| When (UTC) | Status | Method |
+|------------|--------|--------|
+| 2026-06-04 | Done | PR #28 squash-merged to `master` |

--- a/app/controllers/text_clips_controller.rb
+++ b/app/controllers/text_clips_controller.rb
@@ -77,6 +77,7 @@ class TextClipsController < ApplicationController
       built = @current_user.text_clips.build(
         course: course_scoped? ? @context : nil,
         content: attrs[:content],
+        content_html: attrs[:content_html].presence,
         source_url: attrs[:source_url].presence,
         source_title: attrs[:source_title].presence
       )
@@ -105,6 +106,9 @@ class TextClipsController < ApplicationController
                 Array(permitted["tag_ids"]).map(&:to_i).reject(&:zero?)
               end
     attrs = normalized_update_params(permitted.except("tag_ids", "pinned"))
+    if permitted.key?("content") && !permitted.key?("content_html")
+      attrs[:content_html] = nil
+    end
     if permitted.key?("pinned")
       attrs[:pinned_at] = ActiveModel::Type::Boolean.new.cast(permitted["pinned"]) ? Time.now.utc : nil
     end
@@ -221,11 +225,11 @@ class TextClipsController < ApplicationController
   end
 
   def create_params
-    params.permit(:content, :source_url, :source_title)
+    params.permit(:content, :content_html, :source_url, :source_title)
   end
 
   def update_params
-    params.permit(:content, :note, :pinned, tag_ids: [])
+    params.permit(:content, :content_html, :note, :pinned, tag_ids: [])
   end
 
   def index_sort_param
@@ -236,6 +240,7 @@ class TextClipsController < ApplicationController
   def normalized_update_params(permitted = nil)
     attrs = (permitted || update_params.to_h).symbolize_keys
     attrs[:note] = attrs[:note].presence if attrs.key?(:note)
+    attrs[:content_html] = attrs[:content_html].presence if attrs.key?(:content_html)
     attrs
   end
 

--- a/app/models/text_clip.rb
+++ b/app/models/text_clip.rb
@@ -21,6 +21,8 @@ class TextClip < ApplicationRecord
   extend RootAccountResolver
   include Canvas::SoftDeletable
 
+  sanitize_field :content_html, CanvasSanitize::SANITIZE
+
   belongs_to :user
   belongs_to :course, optional: true
   has_many :text_clip_taggings, dependent: :destroy
@@ -41,6 +43,7 @@ class TextClip < ApplicationRecord
 
   validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 50_000 }
+  validates :content_html, length: { maximum: 200_000 }, allow_nil: true
   validates :source_url, length: { maximum: 2048 }, allow_nil: true
   validates :source_title, length: { maximum: 512 }, allow_nil: true
   validates :note, length: { maximum: 10_000 }, allow_nil: true

--- a/app/views/shared_text_clips/show.html.erb
+++ b/app/views/shared_text_clips/show.html.erb
@@ -14,7 +14,13 @@
 </head>
 <body>
   <h1><%= t("Shared text clip", :scope => :text_clips) %></h1>
-  <div class="content"><%= h(@clip.content) %></div>
+  <div class="content">
+    <% if @clip.content_html.present? %>
+      <%= raw @clip.content_html %>
+    <% else %>
+      <%= h(@clip.content) %>
+    <% end %>
+  </div>
   <% if @clip.source_url.present? %>
     <p class="meta">
       <%= t("Source", :scope => :text_clips) %>:

--- a/db/migrate/20260604083000_add_content_html_to_text_clips.rb
+++ b/db/migrate/20260604083000_add_content_html_to_text_clips.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+class AddContentHtmlToTextClips < ActiveRecord::Migration[8.0]
+  tag :predeploy
+
+  def change
+    add_column :text_clips, :content_html, :text
+  end
+end

--- a/lib/api/v1/text_clip.rb
+++ b/lib/api/v1/text_clip.rb
@@ -23,7 +23,7 @@ module Api::V1::TextClip
   include Api::V1::TextClipShare
 
   API_JSON_OPTS = {
-    only: %w[id content source_url source_title note pinned_at user_id course_id workflow_state created_at updated_at]
+    only: %w[id content content_html source_url source_title note pinned_at user_id course_id workflow_state created_at updated_at]
   }.freeze
 
   def text_clip_json(clip, user, session, opts = {})

--- a/spec/controllers/text_clips_controller_spec.rb
+++ b/spec/controllers/text_clips_controller_spec.rb
@@ -236,6 +236,24 @@ describe TextClipsController do
         expect(body["source_title"]).to eql "Assignments Index"
       end
 
+      it "stores and serializes sanitized content_html" do
+        post :create, format: :json, params: {
+          course_id: @course.id,
+          content: "Rich clip",
+          content_html: "<p><strong>Rich</strong> clip</p><script>x</script>"
+        }
+        expect(response).to have_http_status(:created)
+        body = json_parse(response.body)
+        expect(body["content_html"]).to include("<strong>")
+        expect(body["content_html"]).not_to include("<script")
+        clip = @course.shard.activate { TextClip.find(body["id"]) }
+        expect(clip.content_html).not_to include("<script")
+
+        get :index, format: :json, params: { course_id: @course.id }
+        indexed = json_parse(response.body).find { |c| c["id"] == clip.id }
+        expect(indexed["content_html"]).to include("<strong>")
+      end
+
       it "returns forbidden when the user cannot read the course" do
         user_session(@student)
         post :create, format: :json, params: { course_id: @other_course.id, content: "blocked clip" }
@@ -270,6 +288,25 @@ describe TextClipsController do
         expect(clip.content).to eql "Revised clip"
         expect(clip.note).to eql "Study this for the exam"
         expect(body["note"]).to eql "Study this for the exam"
+      end
+
+      it "clears content_html when content is edited without content_html" do
+        @course.shard.activate do
+          @teacher_clip.update!(
+            content_html: "<p><em>Formatted</em></p>"
+          )
+        end
+        put :update, format: :json, params: {
+          course_id: @course.id,
+          id: @teacher_clip.id,
+          content: "Plain only now"
+        }
+        expect(response).to be_successful
+        body = json_parse(response.body)
+        clip = @course.shard.activate { @teacher_clip.reload }
+        expect(clip.content).to eql "Plain only now"
+        expect(clip.content_html).to be_nil
+        expect(body["content_html"]).to be_nil
       end
 
       it "pins and unpins a clip via pinned param" do

--- a/spec/models/text_clip_spec.rb
+++ b/spec/models/text_clip_spec.rb
@@ -273,6 +273,24 @@ describe TextClip do
     end
   end
 
+  describe "content_html sanitization" do
+    it "strips scripts and unsafe attributes while keeping basic formatting" do
+      clip = TextClip.create!(
+        user_id: @student.id,
+        course_id: @course.id,
+        content: "Bold link",
+        content_html: '<p><strong>Bold</strong> <a href="https://example.com" onclick="alert(1)">link</a></p><script>evil()</script><ul><li>one</li></ul>',
+        root_account_id: @course.root_account_id
+      )
+      html = clip.content_html
+      expect(html).not_to include("<script")
+      expect(html).not_to include("onclick")
+      expect(html).to include("<strong>")
+      expect(html).to include("<a")
+      expect(html).to include("<ul>")
+    end
+  end
+
   describe "clip_tags association" do
     it "returns only active tags through active taggings" do
       tag = ClipTag.create!(

--- a/ui/features/navigation_header/react/trays/TextClipsTray.tsx
+++ b/ui/features/navigation_header/react/trays/TextClipsTray.tsx
@@ -246,7 +246,17 @@ function TextClipListItem({
                   data-testid={`text-clip-pinned-${clip.id}`}
                 />
               )}
-              <Text>{clipPreview(clip.content)}</Text>
+              {clip.content_html ? (
+                <View
+                  as="div"
+                  maxHeight="12rem"
+                  overflowY="auto"
+                  data-testid={`text-clip-rich-${clip.id}`}
+                  dangerouslySetInnerHTML={{__html: clip.content_html}}
+                />
+              ) : (
+                <Text>{clipPreview(clip.content)}</Text>
+              )}
             </Flex>
             {clip.tags && clip.tags.length > 0 && (
               <Flex wrap="wrap" margin="xx-small 0 0 0" data-testid={`text-clip-tags-${clip.id}`}>

--- a/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+++ b/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
@@ -86,6 +86,28 @@ describe('TextClipsTray', () => {
     })
   })
 
+  it('renders rich HTML when content_html is present', async () => {
+    window.ENV.COURSE_ID = '15'
+    server.use(
+      http.get('*/api/v1/courses/15/text_clips', () =>
+        HttpResponse.json([
+          {
+            ...baseClip,
+            content: 'Bold text',
+            content_html: '<p><strong>Bold</strong> text</p>',
+          },
+        ]),
+      ),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId('text-clip-rich-1')).toBeInTheDocument())
+    expect(screen.getByTestId('text-clip-rich-1').innerHTML).toContain('<strong>Bold</strong>')
+  })
+
   it('pins a clip via PUT when the pin button is clicked', async () => {
     window.ENV.COURSE_ID = '7'
     const user = userEvent.setup()

--- a/ui/features/text_clips/__tests__/TextClipsSelectionRoot.test.tsx
+++ b/ui/features/text_clips/__tests__/TextClipsSelectionRoot.test.tsx
@@ -194,6 +194,34 @@ describe('TextClipsSelectionRoot', () => {
     })
   })
 
+  it('posts content_html when the selection includes formatting', async () => {
+    const host = document.createElement('p')
+    host.innerHTML = 'See <strong>bold</strong> text'
+    document.body.appendChild(host)
+
+    const strong = host.querySelector('strong')!
+    const range = document.createRange()
+    range.setStart(host.firstChild as Text, 4)
+    range.setEnd(strong.lastChild as Text, strong.lastChild!.textContent!.length)
+    const sel = window.getSelection()!
+    sel.removeAllRanges()
+    sel.addRange(range)
+    document.dispatchEvent(new Event('mouseup'))
+
+    renderRoot()
+    fireEvent.click(await screen.findByTestId('text-clip-selection-button'))
+
+    await waitFor(() => {
+      expect(mockedCreateTextClip).toHaveBeenCalledWith(
+        '42',
+        expect.objectContaining({
+          content: expect.stringContaining('bold'),
+          content_html: expect.stringMatching(/<strong>/),
+        }),
+      )
+    })
+  })
+
   it('does not render the clip button when selection is inside TinyMCE', async () => {
     const tox = document.createElement('div')
     tox.className = 'tox-edit-area'

--- a/ui/features/text_clips/__tests__/getSelectedHtml.test.ts
+++ b/ui/features/text_clips/__tests__/getSelectedHtml.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {getSelectedHtml, hasFormattedHtml} from '../selectionUtils'
+
+describe('getSelectedHtml', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.getSelection()?.removeAllRanges()
+  })
+
+  it('returns empty string when selection is collapsed', () => {
+    const sel = window.getSelection()
+    expect(sel).not.toBeNull()
+    expect(getSelectedHtml(sel)).toBe('')
+  })
+
+  it('returns inner HTML for a range spanning formatted nodes', () => {
+    document.body.innerHTML = '<p>Hello <strong>world</strong></p>'
+    const strong = document.querySelector('strong')!
+    const textNode = strong.firstChild as Text
+    const range = document.createRange()
+    range.setStart(document.querySelector('p')!.firstChild as Text, 6)
+    range.setEnd(textNode, textNode.length)
+    const sel = window.getSelection()!
+    sel.removeAllRanges()
+    sel.addRange(range)
+
+    const html = getSelectedHtml(sel)
+    expect(html).toMatch(/<strong>world<\/strong>/)
+    expect(hasFormattedHtml(html)).toBe(true)
+  })
+})

--- a/ui/features/text_clips/components/TextClipsSelectionRoot.tsx
+++ b/ui/features/text_clips/components/TextClipsSelectionRoot.tsx
@@ -21,11 +21,16 @@ import React, {useCallback, useEffect, useState} from 'react'
 import {showFlashAlert} from '@instructure/platform-alerts'
 import SelectionClipButton from './SelectionClipButton'
 import {createGlobalTextClip, createTextClip} from '../api'
-import {getSelectedText, selectionInsideEditor} from '../selectionUtils'
+import {
+  getSelectedHtml,
+  getSelectedText,
+  hasFormattedHtml,
+  selectionInsideEditor,
+} from '../selectionUtils'
 
 const I18n = createI18nScope('text_clips')
 
-type ClipUiState = {top: number; left: number; text: string} | null
+type ClipUiState = {top: number; left: number; text: string; html: string} | null
 
 export default function TextClipsSelectionRoot() {
   const courseId = window.ENV.COURSE_ID
@@ -48,10 +53,12 @@ export default function TextClipsSelectionRoot() {
       setClipUi(null)
       return
     }
+    const html = getSelectedHtml(sel)
     setClipUi({
       top: rect.bottom + window.scrollY + 4,
       left: rect.left + window.scrollX,
       text,
+      html,
     })
   }, [])
 
@@ -76,6 +83,7 @@ export default function TextClipsSelectionRoot() {
         try {
           const body = {
             content: clipUi.text,
+            ...(hasFormattedHtml(clipUi.html) ? {content_html: clipUi.html} : {}),
             source_url: window.location.href,
             source_title: document.title.slice(0, 512),
           }

--- a/ui/features/text_clips/selectionUtils.ts
+++ b/ui/features/text_clips/selectionUtils.ts
@@ -32,3 +32,15 @@ export function getSelectedText(sel: Selection | null): string {
   if (!sel || sel.isCollapsed) return ''
   return sel.toString().trim()
 }
+
+export function getSelectedHtml(sel: Selection | null): string {
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) return ''
+  const range = sel.getRangeAt(0).cloneRange()
+  const div = document.createElement('div')
+  div.appendChild(range.cloneContents())
+  return div.innerHTML.trim()
+}
+
+export function hasFormattedHtml(html: string): boolean {
+  return /<[a-z][\s\S]*>/i.test(html)
+}

--- a/ui/features/text_clips/types.ts
+++ b/ui/features/text_clips/types.ts
@@ -51,6 +51,7 @@ export type ClipSort = 'recent' | 'oldest' | 'source'
 export type TextClipRecord = {
   id: number | string
   content: string
+  content_html?: string | null
   source_url?: string | null
   source_title?: string | null
   note?: string | null
@@ -68,12 +69,14 @@ export type TextClipRecord = {
 
 export type TextClipCreate = {
   content: string
+  content_html?: string
   source_url?: string
   source_title?: string
 }
 
 export type TextClipUpdate = {
   content?: string
+  content_html?: string
   note?: string
   pinned?: boolean
   tag_ids?: Array<number | string>


### PR DESCRIPTION
## Summary

- Add `content_html` column with server-side `sanitize_field`
- Capture formatted selection HTML on clip; plain `content` unchanged for search
- Render rich HTML in tray/full page and public shared view
- Clear `content_html` when clip text is edited without new HTML

## Test plan

- [x] 70 RSpec, 61 Jest, yarn check:ts
- [ ] Manual: clip bold/link/list; verify tray + share; edit text clears HTML

flag=none

Made with [Cursor](https://cursor.com)