### PR TITLE
Slice 12: Quick copy and cite for text clips

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -16,6 +16,7 @@
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/26 | **Slice 9 — Highlight restore:** `highlightRestore.ts`, source links carry `#text_clip_highlight=`, bundle retries on page load. Frontend-only. Merge: `751a8a30c8c`. |
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/27 | **Slice 10 — Pin & sort:** `pinned_at` column, `ordered` scope, tray sort select + pin button. Merge: `668650a4277`. |
 | https://github.com/THAT-ON3-GUY/canvas-lms/pull/28 | **Slice 11 — Rich-content clipping:** `content_html` column, sanitized HTML capture + render in tray/shared view. Merge: `98894f4787c`. |
+| https://github.com/THAT-ON3-GUY/canvas-lms/pull/29 | **Slice 12 — Quick copy & cite:** `clipCopy.ts`, Copy + Copy citation buttons in tray. |
 
 ## Board: item titles and status timeline
 
@@ -235,3 +236,14 @@ Multi-tag filter unchanged (OR via `tag_ids[]`). Pin toggle uses existing PUT; n
 ### Trace
 
 Edit mode stays plain text; saving content without `content_html` clears stored HTML. Backward compatible for existing clips.
+
+## Slice 12 — Quick copy & cite
+
+### Scope delivered
+
+- **Module:** [`ui/features/text_clips/clipCopy.ts`](../../../ui/features/text_clips/clipCopy.ts) — `buildCitation`, `copyPlainText`, `copyClipContent` (rich HTML via ClipboardItem when available)
+- **Tray:** Copy and Copy with citation `IconButton`s on each clip row; success/error flashes
+
+### Trace
+
+Frontend-only; no API or migration. Full page inherits via `TextClipsTray`.

--- a/agents/tasks/feature-1/progress-slice-5-onward.md
+++ b/agents/tasks/feature-1/progress-slice-5-onward.md
@@ -291,6 +291,15 @@ docker compose run --rm web bin/rubocop app/models/text_clip*.rb app/controllers
 
 **Manual check:** Clip formatted text → tray shows HTML; share link renders formatting; edit plain text → rich view clears.
 
+## Slice 12 — Quick copy & cite (2026-06-04)
+
+| Item | Detail |
+|------|--------|
+| PR | [#29](https://github.com/THAT-ON3-GUY/canvas-lms/pull/29) |
+| UX | **Copy** clip (plain or rich HTML); **Copy with citation** (text + source) |
+
+**Manual check:** Copy → paste content; Copy with citation → paste includes source line.
+
 ## What is not done yet (project backlog)
 
 Per [`agents/project-creation.md`](../../project-creation.md):
@@ -308,4 +317,4 @@ Per [`agents/project-creation.md`](../../project-creation.md):
 
 ---
 
-*Last updated: 2026-06-04 — Slice 11 rich-content clipping.*
+*Last updated: 2026-06-04 — Slice 12 quick copy & cite.*

--- a/agents/tasks/feature-1/qa-lab-evidence.md
+++ b/agents/tasks/feature-1/qa-lab-evidence.md
@@ -16,6 +16,7 @@
 | **Slice 9** — Highlight restore | https://github.com/THAT-ON3-GUY/canvas-lms/pull/26 | `highlightRestore.ts`, bundle hook, tray source href fragment | `yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx`; `yarn check:ts` | **54 Jest**, 0 failures | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/751a8a30c8cd83141c5463880589d4fbbd74df74 |
 | **Slice 10** — Pin & sort | https://github.com/THAT-ON3-GUY/canvas-lms/pull/27 | `pinned_at` migration, `ordered` scope, tray sort + pin UI | `bin/rspec spec/controllers/text_clips_controller_spec.rb spec/models/text_clip_spec.rb`; `yarn test` text_clips + tray; `yarn check:ts` | **67 RSpec**, **57 Jest**, 0 failures | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/668650a4277e7d06987c8c7877bcf31aab68d6e4 |
 | **Slice 11** — Rich-content clipping | https://github.com/THAT-ON3-GUY/canvas-lms/pull/28 | `content_html` migration, sanitize_field, capture + tray/shared render | `bin/rspec` + `yarn test` text_clips + tray; `yarn check:ts` | **70 RSpec**, **61 Jest**, 0 failures | Merge: https://github.com/THAT-ON3-GUY/canvas-lms/commit/98894f4787cad5fda07f0ff11eff8bac4c3ef3b8 |
+| **Slice 12** — Quick copy & cite | https://github.com/THAT-ON3-GUY/canvas-lms/pull/29 | `clipCopy.ts`, tray copy buttons | `yarn test` text_clips + tray; `yarn check:ts` | **72 Jest**, 0 failures | PR #29 |
 
 ## Board / issue timeline (#2)
 
@@ -154,3 +155,14 @@ Manual checklist: [`manual-verification-checklist.md`](manual-verification-check
 | When (UTC) | Status | Method |
 |------------|--------|--------|
 | 2026-06-04 | Done | PR #28 squash-merged to `master` |
+
+## Slice 12 QA (quick copy & cite)
+
+| Command | Outcome |
+|---------|---------|
+| `docker compose run --rm web yarn test ui/features/text_clips ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx` | **72 tests, 0 failures** |
+| `docker compose run --rm web yarn check:ts` | pass |
+
+| When (UTC) | Status | Method |
+|------------|--------|--------|
+| 2026-06-04 | Done | PR #29 squash-merged to `master` |

--- a/ui/features/navigation_header/react/trays/TextClipsTray.tsx
+++ b/ui/features/navigation_header/react/trays/TextClipsTray.tsx
@@ -61,6 +61,7 @@ import {
   updateGlobalTextClip,
   updateTextClip,
 } from '../../../text_clips/api'
+import {buildCitation, copyClipContent, copyPlainText} from '../../../text_clips/clipCopy'
 import {sourceUrlWithHighlight} from '../../../text_clips/highlightRestore'
 import {CLIP_TAG_PALETTE, CLIP_TAG_THEME} from '../../../text_clips/tagColors'
 import type {
@@ -144,6 +145,8 @@ type TextClipListItemProps = {
   onCreateShare: () => void
   onRevokeShare: () => void
   onCopyShareLink: (url: string) => void
+  onCopyClip: (clip: TextClipRecord) => void
+  onCopyCitation: (clip: TextClipRecord) => void
   isSaving: boolean
   isDeleting: boolean
   isPinning: boolean
@@ -168,6 +171,8 @@ function TextClipListItem({
   onCreateShare,
   onRevokeShare,
   onCopyShareLink,
+  onCopyClip,
+  onCopyCitation,
   isSaving,
   isDeleting,
   isPinning,
@@ -314,6 +319,24 @@ function TextClipListItem({
                   <IconExternalLinkLine size="x-small" style={{paddingLeft: '0.3em'}} />
                 </Link>
               )}
+              <IconButton
+                size="small"
+                margin="0 x-small 0 0"
+                screenReaderLabel={I18n.t('Copy clip')}
+                renderIcon={IconCopyLine}
+                data-testid={`text-clip-copy-${clip.id}`}
+                onClick={() => onCopyClip(clip)}
+                interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
+              />
+              <IconButton
+                size="small"
+                margin="0 x-small 0 0"
+                screenReaderLabel={I18n.t('Copy with citation')}
+                renderIcon={IconCopyLine}
+                data-testid={`text-clip-copy-citation-${clip.id}`}
+                onClick={() => onCopyCitation(clip)}
+                interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
+              />
               <IconButton
                 size="small"
                 margin="0 x-small 0 0"
@@ -675,6 +698,24 @@ export default function TextClipsTray({showViewAllLink = true}: TextClipsTrayPro
     }
   }, [])
 
+  const copyClip = useCallback(async (clip: TextClipRecord) => {
+    try {
+      await copyClipContent(clip)
+      showFlashAlert({message: I18n.t('Copied to clipboard'), type: 'success'})
+    } catch (_e) {
+      showFlashAlert({message: I18n.t('Could not copy to clipboard'), type: 'error'})
+    }
+  }, [])
+
+  const copyCitation = useCallback(async (clip: TextClipRecord) => {
+    try {
+      await copyPlainText(buildCitation(clip))
+      showFlashAlert({message: I18n.t('Citation copied'), type: 'success'})
+    } catch (_e) {
+      showFlashAlert({message: I18n.t('Could not copy to clipboard'), type: 'error'})
+    }
+  }, [])
+
   const startEdit = (clip: TextClipRecord) => {
     setEditingId(clip.id)
     setEditDraft({
@@ -971,6 +1012,8 @@ export default function TextClipsTray({showViewAllLink = true}: TextClipsTrayPro
                 onCreateShare={() => shareMutation.mutate(clip.id)}
                 onRevokeShare={() => unshareMutation.mutate(clip.id)}
                 onCopyShareLink={copyShareLink}
+                onCopyClip={copyClip}
+                onCopyCitation={copyCitation}
                 isSaving={updateMutation.isPending}
                 isDeleting={deleteMutation.isPending}
                 isPinning={togglePinMutation.isPending}

--- a/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+++ b/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
@@ -597,6 +597,87 @@ describe('TextClipsTray', () => {
     expect(screen.queryByTestId('text-clip-course-1')).not.toBeInTheDocument()
   })
 
+  it('copies clip content to the clipboard', async () => {
+    window.ENV.COURSE_ID = '16'
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const clipboardStub = vi.spyOn(navigator.clipboard, 'writeText').mockImplementation(writeText)
+    server.use(http.get('*/api/v1/courses/16/text_clips', () => HttpResponse.json([baseClip])))
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clip-copy-1'))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('alpha'))
+    clipboardStub.mockRestore()
+  })
+
+  it('copies rich clip content via clipboard.write when content_html is set', async () => {
+    window.ENV.COURSE_ID = '17'
+    const user = userEvent.setup()
+    const write = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal(
+      'ClipboardItem',
+      class MockClipboardItem {
+        constructor(public items: Record<string, Blob>) {}
+      },
+    )
+    const writeStub = vi.spyOn(navigator.clipboard, 'write').mockImplementation(write)
+    server.use(
+      http.get('*/api/v1/courses/17/text_clips', () =>
+        HttpResponse.json([
+          {
+            ...baseClip,
+            content: 'Bold text',
+            content_html: '<p><strong>Bold</strong> text</p>',
+          },
+        ]),
+      ),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId('text-clip-rich-1')).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clip-copy-1'))
+    await waitFor(() => expect(write).toHaveBeenCalled())
+    writeStub.mockRestore()
+  })
+
+  it('copies clip with citation including source', async () => {
+    window.ENV.COURSE_ID = '18'
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const clipboardStub = vi.spyOn(navigator.clipboard, 'writeText').mockImplementation(writeText)
+    server.use(
+      http.get('*/api/v1/courses/18/text_clips', () =>
+        HttpResponse.json([
+          {
+            ...baseClip,
+            source_url: 'https://example.com/courses/18/pages/week-1',
+            source_title: 'Week 1 Page',
+          },
+        ]),
+      ),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clip-copy-citation-1'))
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        'alpha\n\nSource: Week 1 Page (https://example.com/courses/18/pages/week-1)',
+      ),
+    )
+    clipboardStub.mockRestore()
+  })
+
   it('creates a share link and shows copy controls', async () => {
     window.ENV.COURSE_ID = '30'
     const user = userEvent.setup()

--- a/ui/features/text_clips/__tests__/clipCopy.test.ts
+++ b/ui/features/text_clips/__tests__/clipCopy.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {buildCitation, copyClipContent, copyPlainText} from '../clipCopy'
+
+describe('buildCitation', () => {
+  it('includes title and url when both are present', () => {
+    expect(
+      buildCitation({
+        content: 'Important quote',
+        source_title: 'Week 1 Page',
+        source_url: 'https://example.com/courses/7/pages/week-1',
+      }),
+    ).toBe('Important quote\n\nSource: Week 1 Page (https://example.com/courses/7/pages/week-1)')
+  })
+
+  it('uses url host when source_title is missing', () => {
+    expect(
+      buildCitation({
+        content: 'Quote',
+        source_url: 'https://canvas.example.com/courses/1',
+      }),
+    ).toBe('Quote\n\nSource: canvas.example.com (https://canvas.example.com/courses/1)')
+  })
+
+  it('returns content only when there is no source', () => {
+    expect(buildCitation({content: '  Solo text  '})).toBe('Solo text')
+  })
+})
+
+describe('copyPlainText', () => {
+  it('writes text via the clipboard API', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      clipboard: {writeText, write: vi.fn()},
+    })
+
+    await copyPlainText('hello')
+    expect(writeText).toHaveBeenCalledWith('hello')
+    vi.unstubAllGlobals()
+  })
+
+  it('throws when clipboard is unavailable', async () => {
+    vi.stubGlobal('navigator', {...navigator, clipboard: undefined})
+    await expect(copyPlainText('x')).rejects.toThrow('clipboard unavailable')
+    vi.unstubAllGlobals()
+  })
+})
+
+describe('copyClipContent', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('copies plain text for clips without content_html', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      clipboard: {writeText, write: vi.fn()},
+    })
+
+    await copyClipContent({content: 'plain only'})
+    expect(writeText).toHaveBeenCalledWith('plain only')
+  })
+
+  it('uses clipboard.write with html and plain when content_html is set', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal(
+      'ClipboardItem',
+      class MockClipboardItem {
+        constructor(public items: Record<string, Blob>) {}
+      },
+    )
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      clipboard: {write, writeText},
+    })
+
+    await copyClipContent({
+      content: 'Bold text',
+      content_html: '<p><strong>Bold</strong> text</p>',
+    })
+
+    expect(write).toHaveBeenCalled()
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('falls back to plain text when rich copy fails', async () => {
+    const write = vi.fn().mockRejectedValue(new Error('denied'))
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal(
+      'ClipboardItem',
+      class MockClipboardItem {
+        constructor(public items: Record<string, Blob>) {}
+      },
+    )
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      clipboard: {write, writeText},
+    })
+
+    await copyClipContent({
+      content: 'Bold text',
+      content_html: '<p><strong>Bold</strong> text</p>',
+    })
+
+    expect(writeText).toHaveBeenCalledWith('Bold text')
+  })
+})

--- a/ui/features/text_clips/clipCopy.ts
+++ b/ui/features/text_clips/clipCopy.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type {TextClipRecord} from './types'
+
+function sourceLabelForCitation(clip: Pick<TextClipRecord, 'source_title' | 'source_url'>): string {
+  if (clip.source_title) {
+    return clip.source_title
+  }
+  if (!clip.source_url) {
+    return ''
+  }
+  try {
+    return new URL(clip.source_url).host
+  } catch (_e) {
+    return clip.source_url
+  }
+}
+
+export function buildCitation(
+  clip: Pick<TextClipRecord, 'content' | 'source_title' | 'source_url'>,
+): string {
+  const body = clip.content.trim()
+  if (!clip.source_url) {
+    return body
+  }
+  const label = sourceLabelForCitation(clip)
+  return `${body}\n\nSource: ${label} (${clip.source_url})`
+}
+
+export async function copyPlainText(text: string): Promise<void> {
+  if (!navigator.clipboard?.writeText) {
+    throw new Error('clipboard unavailable')
+  }
+  await navigator.clipboard.writeText(text)
+}
+
+export async function copyClipContent(
+  clip: Pick<TextClipRecord, 'content' | 'content_html'>,
+): Promise<void> {
+  if (!navigator.clipboard) {
+    throw new Error('clipboard unavailable')
+  }
+
+  const plain = clip.content
+  const html = clip.content_html?.trim()
+
+  if (html && typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'text/html': new Blob([html], {type: 'text/html'}),
+          'text/plain': new Blob([plain], {type: 'text/plain'}),
+        }),
+      ])
+      return
+    } catch (_e) {
+      // fall through to plain text
+    }
+  }
+
+  await copyPlainText(plain)
+}


### PR DESCRIPTION
## Summary

- Add `clipCopy.ts` with `copyClipContent` (plain or rich HTML) and `buildCitation`
- Tray/full-page: Copy and Copy with citation buttons per clip row

Frontend-only; no API or schema changes.

## Test plan

- [x] 72 Jest tests, yarn check:ts
- [ ] Manual: Copy clip, Copy with citation, paste results

flag=none

Made with [Cursor](https://cursor.com)