### PR TITLE
Slice 13: Gate text clips behind account feature flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -634,6 +634,7 @@ class ApplicationController < ActionController::Base
     widget_dashboard
     default_discussion_options
     course_navigation_and_feature_options_permissions
+    text_clips
   ].freeze
   JS_ENV_ROOT_ACCOUNT_SERVICES = %i[account_survey_notifications].freeze
   JS_ENV_BRAND_ACCOUNT_FEATURES = %i[

--- a/app/controllers/clip_tags_controller.rb
+++ b/app/controllers/clip_tags_controller.rb
@@ -24,6 +24,7 @@
 #
 class ClipTagsController < ApplicationController
   include Api::V1::ClipTag
+  include TextClipsFeature
 
   before_action :require_user
 

--- a/app/controllers/concerns/text_clips_feature.rb
+++ b/app/controllers/concerns/text_clips_feature.rb
@@ -18,14 +18,16 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-class TextClipsPagesController < ApplicationController
-  include TextClipsFeature
+module TextClipsFeature
+  extend ActiveSupport::Concern
 
-  before_action :require_user
+  included do
+    before_action :require_text_clips_feature
+  end
 
-  def show
-    @page_title = t("text_clips.Text clips")
-    add_crumb @page_title, text_clips_page_path
-    render :show
+  private
+
+  def require_text_clips_feature
+    not_found unless @domain_root_account&.feature_enabled?(:text_clips)
   end
 end

--- a/app/controllers/text_clips_controller.rb
+++ b/app/controllers/text_clips_controller.rb
@@ -24,6 +24,7 @@
 #
 class TextClipsController < ApplicationController
   include Api::V1::TextClip
+  include TextClipsFeature
 
   before_action :require_user
   before_action :load_clip_context

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -71,7 +71,7 @@
   <%= render_datadog_rum_js %>
   <script>if (navigator.userAgent.match(/(MSIE|Trident\/)/)) location.replace('/ie-is-not-supported.html')</script>
   <% js_bundle :navigation_header unless @headers == false %>
-  <% js_bundle :text_clips if @context.is_a?(Course) && @current_user %>
+  <% js_bundle :text_clips if @context.is_a?(Course) && @current_user && @domain_root_account&.feature_enabled?(:text_clips) %>
   <% js_env({ active_context_tab: get_active_tab }) %>
   <script>
     INST = <%= benchmark("rendering INST") { raw(inst_env.to_json) } %>;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
   css_bundle(:instructure_eportfolio) if @eportfolio_view === true
   css_bundle(:new_user_tutorials) if tutorials_enabled?
   js_bundle(:navigation_header) unless @headers == false
-  js_bundle(:text_clips) if @current_user
+  js_bundle(:text_clips) if @current_user && @domain_root_account&.feature_enabled?(:text_clips)
 
   if @domain_root_account&.feature_enabled?(:top_navigation_placement)
     js_env({ INIT_DRAWER_LAYOUT_MUTEX: "init-drawer-layout" })

--- a/app/views/shared/_new_nav_header.html.erb
+++ b/app/views/shared/_new_nav_header.html.erb
@@ -223,7 +223,7 @@
       <% unless @current_user.nil? %>
         <%= render(partial: 'external_tools/global_nav_menu_items') %>
       <% end %>
-      <% if @current_user %>
+      <% if @current_user && @domain_root_account&.feature_enabled?(:text_clips) %>
         <li class="menu-item ic-app-header__menu-list-item">
           <a id="global_nav_text_clips_link" role="button" href="#" class="ic-app-header__menu-list-link">
             <div class="menu-item-icon-container" aria-hidden="true">

--- a/app/views/text_clips_pages/show.html.erb
+++ b/app/views/text_clips_pages/show.html.erb
@@ -17,6 +17,6 @@
 %>
 <%
   provide :page_title, t("text_clips.Text clips")
-  js_bundle :text_clips_page
+  js_bundle :text_clips_page if @domain_root_account&.feature_enabled?(:text_clips)
 %>
 <div id="text_clips_page_mount"></div>

--- a/config/feature_flags/text_clips_flags.yml
+++ b/config/feature_flags/text_clips_flags.yml
@@ -1,0 +1,13 @@
+---
+text_clips:
+  state: hidden
+  display_name: Text clips
+  description: |-
+    Enables the Text clips feature: selection capture, tray, full-page library,
+    tags, sharing, and related APIs for the account.
+  applies_to: Account
+  environments:
+    ci:
+      state: allowed_on
+    development:
+      state: allowed_on

--- a/spec/controllers/clip_tags_controller_spec.rb
+++ b/spec/controllers/clip_tags_controller_spec.rb
@@ -21,6 +21,7 @@
 describe ClipTagsController do
   before :once do
     course_with_teacher_and_student_enrolled(active_all: true)
+    @course.root_account.enable_feature!(:text_clips)
     @teacher_tag = ClipTag.create!(
       user_id: @teacher.id,
       name: "Teacher tag",

--- a/spec/controllers/shared_text_clips_controller_spec.rb
+++ b/spec/controllers/shared_text_clips_controller_spec.rb
@@ -59,5 +59,14 @@ describe SharedTextClipsController do
       get :show, params: { token: @share.token }, format: :json
       expect(response).to have_http_status(:not_found)
     end
+
+    it "still serves anonymous viewers when text_clips is disabled on the account" do
+      @course.root_account.disable_feature!(:text_clips)
+      get :show, params: {token: @share.token}, format: :json
+      expect(response).to be_successful
+      expect(json_parse(response.body)["content"]).to eq "Public clip body"
+    ensure
+      @course.root_account.enable_feature!(:text_clips)
+    end
   end
 end

--- a/spec/controllers/text_clips_controller_spec.rb
+++ b/spec/controllers/text_clips_controller_spec.rb
@@ -24,6 +24,7 @@ describe TextClipsController do
   before :once do
     course_with_teacher_and_student_enrolled(active_all: true)
     @other_course = course_factory(active_all: true)
+    @course.root_account.enable_feature!(:text_clips)
   end
 
   def create_clip_for(user, course, content)
@@ -653,6 +654,32 @@ describe TextClipsController do
         expect(response).to be_successful
         expect(json_parse(response.body)["token"]).to be_present
       end
+    end
+  end
+
+  context "text_clips feature flag disabled" do
+    before do
+      user_session(@teacher)
+      @course.root_account.disable_feature!(:text_clips)
+    end
+
+    after do
+      @course.root_account.enable_feature!(:text_clips)
+    end
+
+    it "has the feature disabled on the domain root account" do
+      expect(Account.default.feature_enabled?(:text_clips)).to be false
+      expect(@course.root_account.feature_enabled?(:text_clips)).to be false
+    end
+
+    it "returns not found for index" do
+      get :index, format: :json, params: {course_id: @course.id}
+      expect(response).to be_not_found
+    end
+
+    it "returns not found for create" do
+      post :create, format: :json, params: {course_id: @course.id, content: "blocked"}
+      expect(response).to be_not_found
     end
   end
 end

--- a/spec/controllers/text_clips_pages_controller_spec.rb
+++ b/spec/controllers/text_clips_pages_controller_spec.rb
@@ -21,6 +21,7 @@
 describe TextClipsPagesController do
   before :once do
     course_with_teacher(active_all: true)
+    @course.root_account.enable_feature!(:text_clips)
   end
 
   describe "GET #show" do
@@ -36,6 +37,15 @@ describe TextClipsPagesController do
       expect(response).to be_successful
       expect(response).to render_template(:show)
       expect(response.body).to include('id="text_clips_page_mount"')
+    end
+
+    it "returns not found when the feature flag is disabled" do
+      @course.root_account.disable_feature!(:text_clips)
+      user_session(@teacher)
+      get :show
+      expect(response).to be_not_found
+    ensure
+      @course.root_account.enable_feature!(:text_clips)
     end
   end
 end

--- a/ui/features/navigation_header/react/OldSideNav.tsx
+++ b/ui/features/navigation_header/react/OldSideNav.tsx
@@ -66,13 +66,15 @@ type ActiveItem =
   | 'help'
   | null
 
+const textClipsEnabled = Boolean(window.ENV.FEATURES?.text_clips)
+
 const itemsWithResources = [
   'courses',
   'groups',
   'accounts',
   'profile',
   'history',
-  'text_clips',
+  ...(textClipsEnabled ? (['text_clips'] as const) : []),
   'help',
 ] as const
 
@@ -244,7 +246,7 @@ const Navigation = () => {
               {type === 'accounts' && <AccountsTray />}
               {type === 'profile' && <ProfileTray />}
               {type === 'history' && <HistoryTray />}
-              {type === 'text_clips' && <TextClipsTray />}
+              {textClipsEnabled && type === 'text_clips' && <TextClipsTray />}
               {type === 'help' && <HelpTray closeTray={closeTray} />}
             </React.Suspense>
           </div>

--- a/ui/features/navigation_header/react/SideNav.tsx
+++ b/ui/features/navigation_header/react/SideNav.tsx
@@ -204,16 +204,20 @@ const SideNav: React.FC<ISideNav> = ({externalTools = []}) => {
     persister: sessionStoragePersister.persisterFn,
   })
 
+  const textClipsEnabled = Boolean(ENV.FEATURES?.text_clips)
+
   useEffect(() => {
+    if (!textClipsEnabled) return
     if (sessionStorage.getItem('text_clips_tray_open') === '1') {
       dispatch({type: 'SET_ACTIVE_TRAY', payload: 'textClips'})
     }
-  }, [])
+  }, [textClipsEnabled])
 
   useEffect(() => {
+    if (!textClipsEnabled) return
     const open = activeTray === 'textClips' && isTrayOpen
     sessionStorage.setItem('text_clips_tray_open', open ? '1' : '0')
-  }, [isTrayOpen, activeTray])
+  }, [isTrayOpen, activeTray, textClipsEnabled])
 
   useLayoutEffect(() => {
     const collapseDiv = document.querySelectorAll('[aria-label="Main navigation"]')[0]
@@ -471,22 +475,24 @@ const SideNav: React.FC<ISideNav> = ({externalTools = []}) => {
             )
           })}
 
-          <SideNavBar.Item
-            id="text-clips-tray"
-            icon={<IconBookmarkLine />}
-            label={I18n.t('Text clips')}
-            href="#"
-            onClick={event => {
-              event.preventDefault()
-              handleActiveTray('textClips', true)
-            }}
-            selected={selectedNavItem === 'textClips'}
-            data-selected={selectedNavItem === 'textClips'}
-            themeOverride={{
-              fontWeight: 400,
-            }}
-            minimized={collapseSideNav}
-          />
+          {textClipsEnabled && (
+            <SideNavBar.Item
+              id="text-clips-tray"
+              icon={<IconBookmarkLine />}
+              label={I18n.t('Text clips')}
+              href="#"
+              onClick={event => {
+                event.preventDefault()
+                handleActiveTray('textClips', true)
+              }}
+              selected={selectedNavItem === 'textClips'}
+              data-selected={selectedNavItem === 'textClips'}
+              themeOverride={{
+                fontWeight: 400,
+              }}
+              minimized={collapseSideNav}
+            />
+          )}
 
           <SideNavBar.Item
             id="help-tray"
@@ -580,7 +586,7 @@ const SideNav: React.FC<ISideNav> = ({externalTools = []}) => {
                     closeTray={() => dispatch({type: 'SET_IS_TRAY_OPEN', payload: false})}
                   />
                 )}
-                {activeTray === 'textClips' && <TextClipsTray />}
+                {textClipsEnabled && activeTray === 'textClips' && <TextClipsTray />}
               </React.Suspense>
             </div>
           </div>

--- a/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+++ b/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
@@ -60,6 +60,7 @@ describe('TextClipsTray', () => {
   const oldCourseId = window.ENV.COURSE_ID
 
   beforeAll(() => {
+    window.ENV.FEATURES = {...window.ENV.FEATURES, text_clips: true}
     server.listen()
     server.use(http.get('*/api/v1/users/self/clip_tags', () => HttpResponse.json([])))
   })

--- a/ui/shared/global/env/EnvCommon.d.ts
+++ b/ui/shared/global/env/EnvCommon.d.ts
@@ -383,6 +383,7 @@ export type RootAccountFeatureId =
   | 'send_usage_metrics'
   | 'substitution_variable_display'
   | 'send_usage_metrics_after_consent'
+  | 'text_clips'
   | 'top_navigation_placement'
   | 'course_navigation_and_feature_options_permissions'
 


### PR DESCRIPTION
## Summary
- Add `text_clips` account feature flag (hidden; allowed in dev/ci)
- Gate API (`TextClipsController`, `ClipTagsController`), full page, JS bundles, and nav
- Keep anonymous shared links public via `SharedTextClipsController`
- Expose flag in `ENV.FEATURES.text_clips` for SideNav / classic nav

## Test plan
- `bin/rspec` text_clips + clip_tags + shared_text_clips controller specs (63 examples)
- `yarn check:ts`
- Manual: disable flag → tray hidden, API 404; shared URL still works

Made with [Cursor](https://cursor.com)