### PR TITLE
Slice 14: Export and bulk clip actions

### DIFF
--- a/ui/features/navigation_header/react/trays/TextClipsTray.tsx
+++ b/ui/features/navigation_header/react/trays/TextClipsTray.tsx
@@ -19,6 +19,7 @@
 import {useScope as createI18nScope} from '@canvas/i18n'
 import {Alert} from '@instructure/ui-alerts'
 import {Button, IconButton} from '@instructure/ui-buttons'
+import {Checkbox} from '@instructure/ui-checkbox'
 import {Flex} from '@instructure/ui-flex'
 import {Heading} from '@instructure/ui-heading'
 import {
@@ -62,6 +63,7 @@ import {
   updateTextClip,
 } from '../../../text_clips/api'
 import {buildCitation, copyClipContent, copyPlainText} from '../../../text_clips/clipCopy'
+import {downloadClipsExport, type ExportFormat} from '../../../text_clips/exportClips'
 import {sourceUrlWithHighlight} from '../../../text_clips/highlightRestore'
 import {CLIP_TAG_PALETTE, CLIP_TAG_THEME} from '../../../text_clips/tagColors'
 import type {
@@ -147,6 +149,8 @@ type TextClipListItemProps = {
   onCopyShareLink: (url: string) => void
   onCopyClip: (clip: TextClipRecord) => void
   onCopyCitation: (clip: TextClipRecord) => void
+  bulkSelected: boolean
+  onToggleBulkSelect: () => void
   isSaving: boolean
   isDeleting: boolean
   isPinning: boolean
@@ -173,6 +177,8 @@ function TextClipListItem({
   onCopyShareLink,
   onCopyClip,
   onCopyCitation,
+  bulkSelected,
+  onToggleBulkSelect,
   isSaving,
   isDeleting,
   isPinning,
@@ -243,184 +249,200 @@ function TextClipListItem({
           </>
         ) : (
           <>
-            <Flex alignItems="center" gap="xx-small">
-              {clip.pinned && (
-                <IconPinSolid
-                  size="x-small"
-                  color="secondary"
-                  data-testid={`text-clip-pinned-${clip.id}`}
-                />
-              )}
-              {clip.content_html ? (
-                <View
-                  as="div"
-                  maxHeight="12rem"
-                  overflowY="auto"
-                  data-testid={`text-clip-rich-${clip.id}`}
-                  dangerouslySetInnerHTML={{__html: clip.content_html}}
-                />
-              ) : (
-                <Text>{clipPreview(clip.content)}</Text>
-              )}
-            </Flex>
-            {clip.tags && clip.tags.length > 0 && (
-              <Flex wrap="wrap" margin="xx-small 0 0 0" data-testid={`text-clip-tags-${clip.id}`}>
-                {clip.tags.map(tag => (
-                  <ClipTagChip
-                    key={String(tag.id)}
-                    tag={tag}
-                    testId={`text-clip-tag-${clip.id}-${tag.id}`}
-                  />
-                ))}
-              </Flex>
-            )}
-            {clip.note && (
-              <View margin="xx-small 0 0 0">
-                <Text
-                  as="div"
-                  size="small"
-                  fontStyle="italic"
-                  data-testid={`text-clip-note-${clip.id}`}
-                >
-                  {clipPreview(clip.note, 120)}
-                </Text>
-              </View>
-            )}
-            {showCourseLabel && clip.course && (
-              <Text
-                as="div"
-                size="x-small"
-                color="secondary"
-                data-testid={`text-clip-course-${clip.id}`}
-              >
-                {clip.course.name}
-              </Text>
-            )}
-            {clip.share && (
-              <View margin="xx-small 0 0 0">
-                <Tag
-                  text={I18n.t('Shared')}
-                  margin="0"
-                  data-testid={`text-clip-shared-badge-${clip.id}`}
-                />
-              </View>
-            )}
-            <View margin="xx-small 0 0 0">
-              {clip.source_url && (
-                <Link
-                  isWithinText={false}
-                  href={sourceUrlWithHighlight(clip) ?? clip.source_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-testid={`text-clip-source-${clip.id}`}
-                  margin="0 x-small 0 0"
-                >
-                  {sourceLinkLabel(clip)}
-                  <IconExternalLinkLine size="x-small" style={{paddingLeft: '0.3em'}} />
-                </Link>
-              )}
-              <IconButton
-                size="small"
-                margin="0 x-small 0 0"
-                screenReaderLabel={I18n.t('Copy clip')}
-                renderIcon={IconCopyLine}
-                data-testid={`text-clip-copy-${clip.id}`}
-                onClick={() => onCopyClip(clip)}
-                interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
+            <Flex alignItems="start" gap="x-small">
+              <Checkbox
+                label={I18n.t('Select clip')}
+                checked={bulkSelected}
+                onChange={onToggleBulkSelect}
+                data-testid={`text-clip-select-${clip.id}`}
               />
-              <IconButton
-                size="small"
-                margin="0 x-small 0 0"
-                screenReaderLabel={I18n.t('Copy with citation')}
-                renderIcon={IconCopyLine}
-                data-testid={`text-clip-copy-citation-${clip.id}`}
-                onClick={() => onCopyCitation(clip)}
-                interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
-              />
-              <IconButton
-                size="small"
-                margin="0 x-small 0 0"
-                screenReaderLabel={clip.pinned ? I18n.t('Unpin clip') : I18n.t('Pin clip to top')}
-                renderIcon={clip.pinned ? IconPinSolid : IconPinLine}
-                data-testid={`text-clip-pin-${clip.id}`}
-                onClick={() => onTogglePin(clip)}
-                interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
-              />
-              <IconButton
-                size="small"
-                margin="0 x-small 0 0"
-                screenReaderLabel={I18n.t('Share clip')}
-                renderIcon={IconLinkLine}
-                data-testid={`text-clip-share-${clip.id}`}
-                onClick={onToggleSharePanel}
-                interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
-              />
-              <IconButton
-                size="small"
-                margin="0 x-small 0 0"
-                screenReaderLabel={I18n.t('Edit clip')}
-                renderIcon={IconEditLine}
-                data-testid={`text-clip-edit-${clip.id}`}
-                onClick={() => onStartEdit(clip)}
-                interaction={isDeleting || isPinning ? 'disabled' : 'enabled'}
-              />
-              <IconButton
-                size="small"
-                screenReaderLabel={I18n.t('Delete clip')}
-                renderIcon={IconTrashLine}
-                data-testid={`text-clip-delete-${clip.id}`}
-                onClick={() => onDelete(clip)}
-                interaction={isDeleting || isPinning ? 'disabled' : 'enabled'}
-              />
-            </View>
-            {sharePanelOpen && (
-              <View
-                margin="x-small 0 0 0"
-                padding="small"
-                borderWidth="small"
-                data-testid={`text-clip-share-panel-${clip.id}`}
-              >
-                {clip.share ? (
-                  <>
-                    <TextInput
-                      renderLabel={I18n.t('Share link')}
-                      value={clip.share.url}
-                      readOnly={true}
-                      data-testid={`text-clip-share-url-${clip.id}`}
+              <View display="block" width="100%">
+                <Flex alignItems="center" gap="xx-small">
+                  {clip.pinned && (
+                    <IconPinSolid
+                      size="x-small"
+                      color="secondary"
+                      data-testid={`text-clip-pinned-${clip.id}`}
                     />
-                    <Flex margin="x-small 0 0 0">
+                  )}
+                  {clip.content_html ? (
+                    <View
+                      as="div"
+                      maxHeight="12rem"
+                      overflowY="auto"
+                      data-testid={`text-clip-rich-${clip.id}`}
+                      dangerouslySetInnerHTML={{__html: clip.content_html}}
+                    />
+                  ) : (
+                    <Text>{clipPreview(clip.content)}</Text>
+                  )}
+                </Flex>
+                {clip.tags && clip.tags.length > 0 && (
+                  <Flex
+                    wrap="wrap"
+                    margin="xx-small 0 0 0"
+                    data-testid={`text-clip-tags-${clip.id}`}
+                  >
+                    {clip.tags.map(tag => (
+                      <ClipTagChip
+                        key={String(tag.id)}
+                        tag={tag}
+                        testId={`text-clip-tag-${clip.id}-${tag.id}`}
+                      />
+                    ))}
+                  </Flex>
+                )}
+                {clip.note && (
+                  <View margin="xx-small 0 0 0">
+                    <Text
+                      as="div"
+                      size="small"
+                      fontStyle="italic"
+                      data-testid={`text-clip-note-${clip.id}`}
+                    >
+                      {clipPreview(clip.note, 120)}
+                    </Text>
+                  </View>
+                )}
+                {showCourseLabel && clip.course && (
+                  <Text
+                    as="div"
+                    size="x-small"
+                    color="secondary"
+                    data-testid={`text-clip-course-${clip.id}`}
+                  >
+                    {clip.course.name}
+                  </Text>
+                )}
+                {clip.share && (
+                  <View margin="xx-small 0 0 0">
+                    <Tag
+                      text={I18n.t('Shared')}
+                      margin="0"
+                      data-testid={`text-clip-shared-badge-${clip.id}`}
+                    />
+                  </View>
+                )}
+                <View margin="xx-small 0 0 0">
+                  {clip.source_url && (
+                    <Link
+                      isWithinText={false}
+                      href={sourceUrlWithHighlight(clip) ?? clip.source_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-testid={`text-clip-source-${clip.id}`}
+                      margin="0 x-small 0 0"
+                    >
+                      {sourceLinkLabel(clip)}
+                      <IconExternalLinkLine size="x-small" style={{paddingLeft: '0.3em'}} />
+                    </Link>
+                  )}
+                  <IconButton
+                    size="small"
+                    margin="0 x-small 0 0"
+                    screenReaderLabel={I18n.t('Copy clip')}
+                    renderIcon={IconCopyLine}
+                    data-testid={`text-clip-copy-${clip.id}`}
+                    onClick={() => onCopyClip(clip)}
+                    interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
+                  />
+                  <IconButton
+                    size="small"
+                    margin="0 x-small 0 0"
+                    screenReaderLabel={I18n.t('Copy with citation')}
+                    renderIcon={IconCopyLine}
+                    data-testid={`text-clip-copy-citation-${clip.id}`}
+                    onClick={() => onCopyCitation(clip)}
+                    interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
+                  />
+                  <IconButton
+                    size="small"
+                    margin="0 x-small 0 0"
+                    screenReaderLabel={
+                      clip.pinned ? I18n.t('Unpin clip') : I18n.t('Pin clip to top')
+                    }
+                    renderIcon={clip.pinned ? IconPinSolid : IconPinLine}
+                    data-testid={`text-clip-pin-${clip.id}`}
+                    onClick={() => onTogglePin(clip)}
+                    interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
+                  />
+                  <IconButton
+                    size="small"
+                    margin="0 x-small 0 0"
+                    screenReaderLabel={I18n.t('Share clip')}
+                    renderIcon={IconLinkLine}
+                    data-testid={`text-clip-share-${clip.id}`}
+                    onClick={onToggleSharePanel}
+                    interaction={isDeleting || isPinning || isSharing ? 'disabled' : 'enabled'}
+                  />
+                  <IconButton
+                    size="small"
+                    margin="0 x-small 0 0"
+                    screenReaderLabel={I18n.t('Edit clip')}
+                    renderIcon={IconEditLine}
+                    data-testid={`text-clip-edit-${clip.id}`}
+                    onClick={() => onStartEdit(clip)}
+                    interaction={isDeleting || isPinning ? 'disabled' : 'enabled'}
+                  />
+                  <IconButton
+                    size="small"
+                    screenReaderLabel={I18n.t('Delete clip')}
+                    renderIcon={IconTrashLine}
+                    data-testid={`text-clip-delete-${clip.id}`}
+                    onClick={() => onDelete(clip)}
+                    interaction={isDeleting || isPinning ? 'disabled' : 'enabled'}
+                  />
+                </View>
+                {sharePanelOpen && (
+                  <View
+                    margin="x-small 0 0 0"
+                    padding="small"
+                    borderWidth="small"
+                    data-testid={`text-clip-share-panel-${clip.id}`}
+                  >
+                    {clip.share ? (
+                      <>
+                        <TextInput
+                          renderLabel={I18n.t('Share link')}
+                          value={clip.share.url}
+                          readOnly={true}
+                          data-testid={`text-clip-share-url-${clip.id}`}
+                        />
+                        <Flex margin="x-small 0 0 0">
+                          <Button
+                            size="small"
+                            margin="0 x-small 0 0"
+                            renderIcon={<IconCopyLine />}
+                            data-testid={`text-clip-copy-link-${clip.id}`}
+                            onClick={() => onCopyShareLink(clip.share!.url)}
+                          >
+                            {I18n.t('Copy link')}
+                          </Button>
+                          <Button
+                            size="small"
+                            color="danger"
+                            data-testid={`text-clip-stop-sharing-${clip.id}`}
+                            onClick={onRevokeShare}
+                            interaction={isSharing ? 'disabled' : 'enabled'}
+                          >
+                            {I18n.t('Stop sharing')}
+                          </Button>
+                        </Flex>
+                      </>
+                    ) : (
                       <Button
                         size="small"
-                        margin="0 x-small 0 0"
-                        renderIcon={<IconCopyLine />}
-                        data-testid={`text-clip-copy-link-${clip.id}`}
-                        onClick={() => onCopyShareLink(clip.share!.url)}
-                      >
-                        {I18n.t('Copy link')}
-                      </Button>
-                      <Button
-                        size="small"
-                        color="danger"
-                        data-testid={`text-clip-stop-sharing-${clip.id}`}
-                        onClick={onRevokeShare}
+                        data-testid={`text-clip-create-link-${clip.id}`}
+                        onClick={onCreateShare}
                         interaction={isSharing ? 'disabled' : 'enabled'}
                       >
-                        {I18n.t('Stop sharing')}
+                        {I18n.t('Create link')}
                       </Button>
-                    </Flex>
-                  </>
-                ) : (
-                  <Button
-                    size="small"
-                    data-testid={`text-clip-create-link-${clip.id}`}
-                    onClick={onCreateShare}
-                    interaction={isSharing ? 'disabled' : 'enabled'}
-                  >
-                    {I18n.t('Create link')}
-                  </Button>
+                    )}
+                  </View>
                 )}
               </View>
-            )}
+            </Flex>
           </>
         )}
       </View>
@@ -450,6 +472,8 @@ export default function TextClipsTray({showViewAllLink = true}: TextClipsTrayPro
   const [renameDraft, setRenameDraft] = useState('')
   const [sharePanelClipId, setSharePanelClipId] = useState<number | string | null>(null)
   const [sort, setSort] = useState<ClipSort>('recent')
+  const [bulkSelectedIds, setBulkSelectedIds] = useState<Set<number | string>>(new Set())
+  const [exportFormat, setExportFormat] = useState<ExportFormat>('markdown')
 
   useEffect(() => {
     const handle = window.setTimeout(() => {
@@ -516,6 +540,22 @@ export default function TextClipsTray({showViewAllLink = true}: TextClipsTrayPro
     })
 
   const clips = useMemo(() => data?.pages.flatMap(page => page.json) ?? [], [data?.pages])
+
+  useEffect(() => {
+    const clipIds = new Set(clips.map(clip => clip.id))
+    setBulkSelectedIds(prev => {
+      const next = new Set([...prev].filter(id => clipIds.has(id)))
+      return next.size === prev.size ? prev : next
+    })
+  }, [clips])
+
+  const bulkSelectedClips = useMemo(
+    () => clips.filter(clip => bulkSelectedIds.has(clip.id)),
+    [clips, bulkSelectedIds],
+  )
+
+  const exportTargetClips = bulkSelectedClips.length > 0 ? bulkSelectedClips : clips
+  const allVisibleSelected = clips.length > 0 && clips.every(clip => bulkSelectedIds.has(clip.id))
 
   const courseFilterOptions = useMemo(() => {
     if (mode !== 'global') return []
@@ -724,6 +764,77 @@ export default function TextClipsTray({showViewAllLink = true}: TextClipsTrayPro
       tag_ids: (clip.tags ?? []).map(t => t.id),
     })
   }
+
+  const toggleBulkSelect = useCallback((clipId: number | string) => {
+    setBulkSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(clipId)) {
+        next.delete(clipId)
+      } else {
+        next.add(clipId)
+      }
+      return next
+    })
+  }, [])
+
+  const toggleSelectAllVisible = useCallback(() => {
+    setBulkSelectedIds(prev => {
+      if (clips.every(clip => prev.has(clip.id))) {
+        return new Set()
+      }
+      return new Set(clips.map(clip => clip.id))
+    })
+  }, [clips])
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: async (ids: Array<number | string>) => {
+      const deleter =
+        mode === 'course'
+          ? (id: number | string) => deleteTextClip(courseId as string | number, id)
+          : deleteGlobalTextClip
+      await Promise.all(ids.map(id => deleter(id)))
+    },
+    onSuccess: (_data, ids) => {
+      setBulkSelectedIds(new Set())
+      setEditingId(null)
+      setEditDraft(null)
+      setSharePanelClipId(null)
+      invalidateClips()
+      showFlashAlert({
+        message: I18n.t('Deleted %{count} clips', {count: ids.length}),
+        type: 'success',
+      })
+    },
+  })
+
+  const bulkTagMutation = useMutation({
+    mutationFn: async ({ids, tagId}: {ids: Array<number | string>; tagId: number | string}) => {
+      const updater =
+        mode === 'course'
+          ? (id: number | string, body: TextClipUpdate) =>
+              updateTextClip(courseId as string | number, id, body)
+          : updateGlobalTextClip
+      await Promise.all(
+        ids.map(async id => {
+          const clip = clips.find(c => c.id === id)
+          if (!clip) return
+          const existing = new Set((clip.tags ?? []).map(tag => tag.id))
+          existing.add(tagId)
+          await updater(id, {tag_ids: Array.from(existing)})
+        }),
+      )
+    },
+    onSuccess: () => {
+      invalidateClips()
+      showFlashAlert({message: I18n.t('Tags applied to selected clips'), type: 'success'})
+    },
+  })
+
+  const handleExport = useCallback(() => {
+    if (exportTargetClips.length === 0) return
+    downloadClipsExport(exportTargetClips, exportFormat)
+    showFlashAlert({message: I18n.t('Export started'), type: 'success'})
+  }, [exportFormat, exportTargetClips])
 
   return (
     <View as="div" padding="medium" id="text_clips_tray">
@@ -986,6 +1097,79 @@ export default function TextClipsTray({showViewAllLink = true}: TextClipsTrayPro
 
       {!isLoading && !isError && !searchTooShort && clips.length > 0 && (
         <>
+          <View margin="small 0" data-testid="text-clips-bulk-toolbar">
+            <Flex wrap="wrap" alignItems="center" gap="x-small">
+              <Checkbox
+                label={I18n.t('Select all')}
+                checked={allVisibleSelected}
+                indeterminate={bulkSelectedIds.size > 0 && !allVisibleSelected}
+                onChange={toggleSelectAllVisible}
+                data-testid="text-clips-select-all"
+              />
+              {bulkSelectedIds.size > 0 && (
+                <Text size="small" data-testid="text-clips-bulk-count">
+                  {I18n.t('%{count} selected', {count: bulkSelectedIds.size})}
+                </Text>
+              )}
+              <Button
+                size="small"
+                color="danger"
+                data-testid="text-clips-bulk-delete"
+                onClick={() => bulkDeleteMutation.mutate(Array.from(bulkSelectedIds))}
+                interaction={
+                  bulkSelectedIds.size === 0 || bulkDeleteMutation.isPending
+                    ? 'disabled'
+                    : 'enabled'
+                }
+              >
+                {I18n.t('Delete selected')}
+              </Button>
+              <SimpleSelect
+                renderLabel={I18n.t('Export format')}
+                value={exportFormat}
+                onChange={(_e, {value}) => setExportFormat(value as ExportFormat)}
+                data-testid="text-clips-export-format"
+              >
+                <SimpleSelect.Option id="markdown" value="markdown">
+                  {I18n.t('Markdown')}
+                </SimpleSelect.Option>
+                <SimpleSelect.Option id="csv" value="csv">
+                  {I18n.t('CSV')}
+                </SimpleSelect.Option>
+                <SimpleSelect.Option id="json" value="json">
+                  {I18n.t('JSON')}
+                </SimpleSelect.Option>
+              </SimpleSelect>
+              <Button
+                size="small"
+                data-testid="text-clips-export"
+                onClick={handleExport}
+                interaction={exportTargetClips.length === 0 ? 'disabled' : 'enabled'}
+              >
+                {bulkSelectedIds.size > 0 ? I18n.t('Export selected') : I18n.t('Export all loaded')}
+              </Button>
+            </Flex>
+            {bulkSelectedIds.size > 0 && clipTags.length > 0 && (
+              <Flex wrap="wrap" margin="x-small 0 0 0" data-testid="text-clips-bulk-tags">
+                <Text as="span" size="small">
+                  {I18n.t('Add tag to selected:')}
+                </Text>
+                {clipTags.map(tag => (
+                  <ClipTagChip
+                    key={String(tag.id)}
+                    tag={tag}
+                    onClick={() =>
+                      bulkTagMutation.mutate({
+                        ids: Array.from(bulkSelectedIds),
+                        tagId: tag.id,
+                      })
+                    }
+                    testId={`text-clips-bulk-tag-${tag.id}`}
+                  />
+                ))}
+              </Flex>
+            )}
+          </View>
           <List isUnstyled margin="small 0" itemSpacing="small">
             {clips.map(clip => (
               <TextClipListItem
@@ -1014,6 +1198,8 @@ export default function TextClipsTray({showViewAllLink = true}: TextClipsTrayPro
                 onCopyShareLink={copyShareLink}
                 onCopyClip={copyClip}
                 onCopyCitation={copyCitation}
+                bulkSelected={bulkSelectedIds.has(clip.id)}
+                onToggleBulkSelect={() => toggleBulkSelect(clip.id)}
                 isSaving={updateMutation.isPending}
                 isDeleting={deleteMutation.isPending}
                 isPinning={togglePinMutation.isPending}

--- a/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
+++ b/ui/features/navigation_header/react/trays/__tests__/TextClipsTray.test.tsx
@@ -25,6 +25,7 @@ import TextClipsTray, {sourceLinkLabel} from '../TextClipsTray'
 import {MockedQueryProvider} from '@canvas/test-utils/query'
 import type {GlobalEnv} from '@canvas/global/env/GlobalEnv.d'
 import type {TextClipRecord} from '../../../../text_clips/types'
+import * as exportClips from '../../../../text_clips/exportClips'
 
 vi.mock('@instructure/platform-alerts', () => ({
   showFlashAlert: vi.fn(),
@@ -719,6 +720,44 @@ describe('TextClipsTray', () => {
       expect(writeText).toHaveBeenCalledWith('https://example.com/text_clips/shared/secret-token'),
     )
     clipboardStub.mockRestore()
+  })
+
+  it('exports all loaded clips', async () => {
+    window.ENV.COURSE_ID = '40'
+    const user = userEvent.setup()
+    const downloadSpy = vi.spyOn(exportClips, 'downloadClipsExport').mockImplementation(() => {})
+    server.use(http.get('*/api/v1/courses/40/text_clips', () => HttpResponse.json([baseClip])))
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clips-export'))
+    expect(downloadSpy).toHaveBeenCalledWith([baseClip], 'markdown')
+    downloadSpy.mockRestore()
+  })
+
+  it('bulk-deletes selected clips', async () => {
+    window.ENV.COURSE_ID = '41'
+    const user = userEvent.setup()
+    let deleted = false
+    server.use(
+      http.get('*/api/v1/courses/41/text_clips', () => HttpResponse.json([baseClip])),
+      http.delete('*/api/v1/courses/41/text_clips/1', () => {
+        deleted = true
+        return new HttpResponse(null, {status: 200})
+      }),
+    )
+    render(
+      <MockedQueryProvider>
+        <TextClipsTray />
+      </MockedQueryProvider>,
+    )
+    await waitFor(() => expect(screen.getByText(/alpha/)).toBeInTheDocument())
+    await user.click(screen.getByTestId('text-clip-select-1'))
+    await user.click(screen.getByTestId('text-clips-bulk-delete'))
+    await waitFor(() => expect(deleted).toBe(true))
   })
 
   it('stops sharing and hides the shared badge', async () => {

--- a/ui/features/text_clips/__tests__/exportClips.test.ts
+++ b/ui/features/text_clips/__tests__/exportClips.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  clipsToCsv,
+  clipsToJson,
+  clipsToMarkdown,
+  downloadClipsExport,
+  formatClipsForExport,
+} from '../exportClips'
+import type {TextClipRecord} from '../types'
+
+const sampleClip: TextClipRecord = {
+  id: 1,
+  content: 'Hello, "world"',
+  note: 'A note',
+  source_url: 'https://example.com/page',
+  source_title: 'Week 1',
+  tags: [{id: 5, name: 'important', color: 'blue'}],
+  course: {id: 7, name: 'Biology'},
+  user_id: 1,
+  course_id: 7,
+  workflow_state: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+describe('exportClips', () => {
+  it('formats markdown with metadata', () => {
+    const md = clipsToMarkdown([sampleClip])
+    expect(md).toContain('## Week 1')
+    expect(md).toContain('Hello, "world"')
+    expect(md).toContain('Tags: important')
+    expect(md).toContain('Course: Biology')
+  })
+
+  it('escapes csv cells with quotes and commas', () => {
+    const csv = clipsToCsv([sampleClip])
+    expect(csv.split('\n')[0]).toBe(
+      'id,content,note,source_url,source_title,course,tags,created_at',
+    )
+    expect(csv).toContain('"Hello, ""world"""')
+  })
+
+  it('serializes json', () => {
+    const json = clipsToJson([sampleClip])
+    expect(JSON.parse(json)[0].id).toBe(1)
+  })
+
+  it('downloads via a temporary anchor', () => {
+    const click = vi.fn()
+    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement
+    const createElement = vi.spyOn(document, 'createElement').mockReturnValue(anchor)
+    const originalUrl = global.URL
+    const createObjectURL = vi.fn(() => 'blob:1')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', {
+      createObjectURL,
+      revokeObjectURL,
+    })
+
+    try {
+      downloadClipsExport([sampleClip], 'csv', 'my-clips')
+
+      expect(formatClipsForExport([sampleClip], 'csv')).toContain('Hello')
+      expect(anchor.download).toBe('my-clips.csv')
+      expect(click).toHaveBeenCalled()
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:1')
+    } finally {
+      createElement.mockRestore()
+      vi.stubGlobal('URL', originalUrl)
+    }
+  })
+})

--- a/ui/features/text_clips/exportClips.ts
+++ b/ui/features/text_clips/exportClips.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type {TextClipRecord} from './types'
+
+export type ExportFormat = 'markdown' | 'csv' | 'json'
+
+function escapeCsvCell(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+export function clipsToMarkdown(clips: TextClipRecord[]): string {
+  return clips
+    .map(clip => {
+      const title = clip.source_title?.trim() || `Clip ${clip.id}`
+      const lines = [`## ${title}`, '', clip.content.trim()]
+      if (clip.note?.trim()) {
+        lines.push('', `> ${clip.note.trim()}`)
+      }
+      if (clip.tags?.length) {
+        lines.push('', `Tags: ${clip.tags.map(tag => tag.name).join(', ')}`)
+      }
+      if (clip.course?.name) {
+        lines.push('', `Course: ${clip.course.name}`)
+      }
+      if (clip.source_url) {
+        lines.push('', `Source: ${clip.source_url}`)
+      }
+      lines.push('', `Saved: ${clip.created_at}`)
+      return lines.join('\n')
+    })
+    .join('\n\n---\n\n')
+}
+
+export function clipsToCsv(clips: TextClipRecord[]): string {
+  const header = [
+    'id',
+    'content',
+    'note',
+    'source_url',
+    'source_title',
+    'course',
+    'tags',
+    'created_at',
+  ]
+  const rows = clips.map(clip =>
+    [
+      String(clip.id),
+      clip.content,
+      clip.note ?? '',
+      clip.source_url ?? '',
+      clip.source_title ?? '',
+      clip.course?.name ?? '',
+      (clip.tags ?? []).map(tag => tag.name).join('; '),
+      clip.created_at,
+    ]
+      .map(escapeCsvCell)
+      .join(','),
+  )
+  return [header.join(','), ...rows].join('\n')
+}
+
+export function clipsToJson(clips: TextClipRecord[]): string {
+  return JSON.stringify(clips, null, 2)
+}
+
+export function formatClipsForExport(clips: TextClipRecord[], format: ExportFormat): string {
+  switch (format) {
+    case 'markdown':
+      return clipsToMarkdown(clips)
+    case 'csv':
+      return clipsToCsv(clips)
+    case 'json':
+      return clipsToJson(clips)
+  }
+}
+
+export function downloadClipsExport(
+  clips: TextClipRecord[],
+  format: ExportFormat,
+  filenameBase = 'text-clips',
+): void {
+  const content = formatClipsForExport(clips, format)
+  const extension = format === 'markdown' ? 'md' : format
+  const mimeType =
+    format === 'json' ? 'application/json' : format === 'csv' ? 'text/csv' : 'text/markdown'
+  const blob = new Blob([content], {type: `${mimeType};charset=utf-8`})
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `${filenameBase}.${extension}`
+  anchor.click()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
Bulk select/delete/tag and client-side Markdown/CSV/JSON export in TextClipsTray.

Made with [Cursor](https://cursor.com)