### PR TITLE
Enable text_clips flag by default

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -256,7 +256,7 @@ Frontend-only; no API or migration. Full page inherits via `TextClipsTray`.
 
 ### Scope delivered
 
-- **Flag:** [`config/feature_flags/text_clips_flags.yml`](../../../config/feature_flags/text_clips_flags.yml) — `text_clips`, `applies_to: Account`, hidden; dev/ci `allowed_on`
+- **Flag:** [`config/feature_flags/text_clips_flags.yml`](../../../config/feature_flags/text_clips_flags.yml) — `text_clips`, `applies_to: Account`, `allowed_on` by default (all environments)
 - **Gate:** [`TextClipsFeature`](../../../app/controllers/concerns/text_clips_feature.rb) on API, pages, clip tags; bundles and nav; `ENV.FEATURES.text_clips`
 - **Shares:** [`SharedTextClipsController`](../../../app/controllers/shared_text_clips_controller.rb) unchanged (anonymous links work when flag off)
 

--- a/agents/tasks/feature-1/manual-verification-checklist.md
+++ b/agents/tasks/feature-1/manual-verification-checklist.md
@@ -158,4 +158,4 @@
 |------|------|-------|
 | Agent (Slice 16) | 2026-06-04 | Full test pass 93 RSpec + 79 Jest; PRs #30–#33 on fork `master` |
 
-**Lab ship-ready:** slices 1–16 merged; enable `text_clips` per account for production-style rollout.
+**Lab ship-ready:** slices 1–16 merged; `text_clips` is on by default per account (`allowed_on`); disable via account feature flags to test gating.

--- a/agents/tasks/feature-1/progress-slice-5-onward.md
+++ b/agents/tasks/feature-1/progress-slice-5-onward.md
@@ -305,7 +305,7 @@ docker compose run --rm web bin/rubocop app/models/text_clip*.rb app/controllers
 | Item | Detail |
 |------|--------|
 | PR | [#30](https://github.com/THAT-ON3-GUY/canvas-lms/pull/30) — merge `65910ea716e` |
-| Flag | Account `text_clips` (hidden; enable per account in dev/ci) |
+| Flag | Account `text_clips` (`allowed_on` by default; can disable per account) |
 | Gate | API, `/text_clips` page, clip tags, bundles, SideNav/classic nav |
 
 **Manual check:** Disable flag on account → nav hidden, API 404; shared URL still loads anonymously.

--- a/config/feature_flags/text_clips_flags.yml
+++ b/config/feature_flags/text_clips_flags.yml
@@ -1,6 +1,6 @@
 ---
 text_clips:
-  state: hidden
+  state: allowed_on
   display_name: Text clips
   description: |-
     Enables the Text clips feature: selection capture, tray, full-page library,
@@ -10,4 +10,6 @@ text_clips:
     ci:
       state: allowed_on
     development:
+      state: allowed_on
+    production:
       state: allowed_on


### PR DESCRIPTION
## Summary
- Change `text_clips` from `hidden` to `allowed_on` (all environments including production)
- Accounts get Text clips without manual enablement; can still disable per account
- Update feature-1 evidence/checklist docs

## Test plan
- [ ] Log in on a fresh account — Text clips nav appears without enabling the flag
- [ ] Disable flag on account — API 404, nav hidden
- [ ] `bin/rspec` text_clips controller flag specs

Made with [Cursor](https://cursor.com)